### PR TITLE
Fix the file open mode for the tar file from text mode to binary mode

### DIFF
--- a/lib/docker/image.rb
+++ b/lib/docker/image.rb
@@ -113,7 +113,7 @@ class Docker::Image
 
     def create_dir_tar(directory)
       cwd = FileUtils.pwd
-      tempfile = File.new('/tmp/out', 'w')
+      tempfile = File.new('/tmp/out', 'wb')
       FileUtils.cd(directory)
       Archive::Tar::Minitar.pack('.', tempfile)
       File.new('/tmp/out', 'r')


### PR DESCRIPTION
I encountered this error today on my system.

Was trying to pass a local directory to `build_from_dir`, and I traced it to the way that the tempfile is opened in text mode as opposed to binary.

[Ruby Docs](http://www.ruby-doc.org/core-2.0/IO.html#method-c-new)

```
1.9.3p429 :032 > f1 = File.open("/tmp/f1","w")
 => #<File:/tmp/f1>
1.9.3p429 :033 > f2 = File.open("/tmp/f2","wb")
 => #<File:/tmp/f2>
1.9.3p429 :034 > f1.external_encoding
 => #<Encoding:UTF-8>
1.9.3p429 :035 > f2.external_encoding
 => #<Encoding:ASCII-8BIT>
1.9.3p429 :041 > Archive::Tar::Minitar.pack('.', f1)
Encoding::UndefinedConversionError: "\xDF" from ASCII-8BIT to UTF-8
1.9.3p429 :042 > Archive::Tar::Minitar.pack('.', f2)
 => nil
```
