### PR TITLE
Update README to use an explicit "require"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Installation
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'docker-api'
+gem 'docker-api', :require => 'docker'
 ```
 
 And then run:


### PR DESCRIPTION
Hi,

When I was trying to use this gem with bundler, I found that the README's instructions didn't work; the name of this gem and the name of the file that needs to be included are different, which requires that we give an explicit "require" to bundler.
