### PR TITLE
add method for returning response from images list endpoint

### DIFF
--- a/lib/docker/image.rb
+++ b/lib/docker/image.rb
@@ -99,6 +99,11 @@ class Docker::Image
       hashes.map { |hash| new(conn, hash['Id']) }
     end
 
+    # Returns response from list api endpoint.
+    def list(opts = {}, conn = Docker.connection)
+      Docker::Util.parse_json(conn.get('/images/json', opts)) || []
+    end
+
     # Given a query like `{ :term => 'sshd' }`, queries the Docker Registry for
     # a corresponding Image.
     def search(query = {}, connection = Docker.connection)


### PR DESCRIPTION
It appears that there is no easy way to get the repository and tag for an image through the image endpoints.  Unless I misread to get this information one must parse the history and potentially use some sloppy string parsing to spit respository and tag?  

Anyways, this PR adds a method which returns the images/list response directly as opposed to all which instantiates Images.
