### PR TITLE
make command optional to image#run since many images will have default

### DIFF
--- a/lib/docker/image.rb
+++ b/lib/docker/image.rb
@@ -16,7 +16,7 @@ class Docker::Image
   # Given a command and optional list of streams to attach to, run a command on
   # an Image. This will not modify the Image, but rather create a new Container
   # to run the Image.
-  def run(cmd)
+  def run(cmd = nil)
     cmd = cmd.split(/\s+/) if cmd.is_a?(String)
     Docker::Container.create({ 'Image' => self.id, 'Cmd' => cmd }, connection)
                      .tap(&:start!)


### PR DESCRIPTION
Images often have default entry points.  

This allows you to call fun on an image without passing a dummy parameter in those cases.
