### PR TITLE
Feature/fix commit for run

### DIFF
--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -57,7 +57,15 @@ class Docker::Container
   # Create an Image from a Container's change.s
   def commit(options = {})
     options.merge!('container' => self.id[0..7])
-    hash = Docker::Util.parse_json(connection.post('/commit', options))
+    # [code](https://github.com/dotcloud/docker/blob/v0.6.3/commands.go#L1115)
+    # Based on the link, the config passed as run, needs to be passed as the
+    # body of the post so capture it, remove from the options, and pass it via
+    # the post body
+    config = options.delete('run')
+    hash = Docker::Util.parse_json(connection.post('/commit',
+                                                   options,
+                                                   :body => config.to_json)
+                                  )
     Docker::Image.send(:new, self.connection, hash['Id'])
   end
 

--- a/spec/docker/container_spec.rb
+++ b/spec/docker/container_spec.rb
@@ -277,6 +277,14 @@ describe Docker::Container do
       image.should be_a Docker::Image
       image.id.should_not be_nil
     end
+
+    context 'if run is passed, it saves the command in the image', :vcr do
+      let(:image) { subject.commit('run' => {"Cmd" => %w[pwd]}) }
+      it 'saves the command' do
+        image.run.attach.should eql "/\n"
+      end
+    end
+
   end
 
   describe '.create' do

--- a/spec/docker/image_spec.rb
+++ b/spec/docker/image_spec.rb
@@ -145,6 +145,25 @@ describe Docker::Image do
         output.should == "/bin/pwd\n"
       end
     end
+
+    context 'when the argument is nil', :vcr  do
+      let(:cmd) { nil }
+      context 'no command configured in image'do
+        it 'should raise an error if no command is specified' do
+          expect {output}.to raise_error(Docker::Error::ServerError,
+                                         "No command specified.")
+        end
+      end
+
+      context "command configured in image" do
+        let(:container) {Docker::Container.create('Cmd' => %w[true],
+                                                  'Image' => 'base')}
+        subject { container.commit('run' => {"Cmd" => %w[pwd]}) }
+        it 'should normally show result if image has Cmd configured' do
+          output.should eql "/\n"
+        end
+      end
+    end
   end
 
   describe '.create' do

--- a/spec/vcr/Docker_Container/_commit/if_run_is_passed_it_saves_the_command_in_the_image/saves_the_command.yml
+++ b/spec/vcr/Docker_Container/_commit/if_run_is_passed_it_saves_the_command_in_the_image/saves_the_command.yml
@@ -1,0 +1,181 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://unix/v1.4/containers/create
+    body:
+      encoding: UTF-8
+      string: ! '{"Cmd":["true"],"Image":"base"}'
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.6.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: ''
+    headers:
+      !binary "Q29udGVudC1UeXBl":
+      - !binary |-
+        YXBwbGljYXRpb24vanNvbg==
+      !binary "Q29udGVudC1MZW5ndGg=":
+      - !binary |-
+        MTM1
+      !binary "RGF0ZQ==":
+      - !binary |-
+        VHVlLCAyOSBPY3QgMjAxMyAyMTo1OToyNiBHTVQ=
+    body:
+      encoding: US-ASCII
+      string: ! '{"Id":"96b3bf2d511e","Warnings":["Docker detected local DNS server
+        on resolv.conf. Using default external servers: [8.8.8.8 8.8.4.4]"]}'
+    http_version:
+  recorded_at: Tue, 29 Oct 2013 21:59:26 GMT
+- request:
+    method: post
+    uri: http://unix/v1.4/containers/96b3bf2d511e/start
+    body:
+      encoding: UTF-8
+      string: ! '{}'
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.6.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 204
+      message: ''
+    headers:
+      !binary "Q29udGVudC1UeXBl":
+      - !binary |-
+        dGV4dC9wbGFpbjsgY2hhcnNldD11dGYtOA==
+      !binary "Q29udGVudC1MZW5ndGg=":
+      - !binary |-
+        MA==
+      !binary "RGF0ZQ==":
+      - !binary |-
+        VHVlLCAyOSBPY3QgMjAxMyAyMTo1OToyNiBHTVQ=
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version:
+  recorded_at: Tue, 29 Oct 2013 21:59:26 GMT
+- request:
+    method: post
+    uri: http://unix/v1.4/commit?container=96b3bf2d
+    body:
+      encoding: UTF-8
+      string: ! '{"Cmd":["pwd"]}'
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.6.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: ''
+    headers:
+      !binary "Q29udGVudC1UeXBl":
+      - !binary |-
+        YXBwbGljYXRpb24vanNvbg==
+      !binary "Q29udGVudC1MZW5ndGg=":
+      - !binary |-
+        MjE=
+      !binary "RGF0ZQ==":
+      - !binary |-
+        VHVlLCAyOSBPY3QgMjAxMyAyMTo1OToyNiBHTVQ=
+    body:
+      encoding: US-ASCII
+      string: ! '{"Id":"a10fab209e57"}'
+    http_version:
+  recorded_at: Tue, 29 Oct 2013 21:59:26 GMT
+- request:
+    method: post
+    uri: http://unix/v1.4/containers/create
+    body:
+      encoding: UTF-8
+      string: ! '{"Image":"a10fab209e57"}'
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.6.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: ''
+    headers:
+      !binary "Q29udGVudC1UeXBl":
+      - !binary |-
+        YXBwbGljYXRpb24vanNvbg==
+      !binary "Q29udGVudC1MZW5ndGg=":
+      - !binary |-
+        MTM1
+      !binary "RGF0ZQ==":
+      - !binary |-
+        VHVlLCAyOSBPY3QgMjAxMyAyMTo1OToyNiBHTVQ=
+    body:
+      encoding: US-ASCII
+      string: ! '{"Id":"459ab8af8f81","Warnings":["Docker detected local DNS server
+        on resolv.conf. Using default external servers: [8.8.8.8 8.8.4.4]"]}'
+    http_version:
+  recorded_at: Tue, 29 Oct 2013 21:59:26 GMT
+- request:
+    method: post
+    uri: http://unix/v1.4/containers/459ab8af8f81/start
+    body:
+      encoding: UTF-8
+      string: ! '{}'
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.6.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 204
+      message: ''
+    headers:
+      !binary "Q29udGVudC1UeXBl":
+      - !binary |-
+        dGV4dC9wbGFpbjsgY2hhcnNldD11dGYtOA==
+      !binary "Q29udGVudC1MZW5ndGg=":
+      - !binary |-
+        MA==
+      !binary "RGF0ZQ==":
+      - !binary |-
+        VHVlLCAyOSBPY3QgMjAxMyAyMTo1OToyNiBHTVQ=
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version:
+  recorded_at: Tue, 29 Oct 2013 21:59:26 GMT
+- request:
+    method: post
+    uri: http://unix/v1.4/containers/459ab8af8f81/attach?stdout=true&stream=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.6.0
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      !binary "Q29udGVudC1UeXBl":
+      - !binary |-
+        YXBwbGljYXRpb24vdm5kLmRvY2tlci5yYXctc3RyZWFt
+    body:
+      encoding: US-ASCII
+      string: ! '/
+
+'
+    http_version:
+  recorded_at: Tue, 29 Oct 2013 21:59:26 GMT
+recorded_with: VCR 2.6.0

--- a/spec/vcr/Docker_Image/_run/when_the_argument_is_nil/command_configured_in_image/should_normally_show_result_if_image_has_Cmd_configured.yml
+++ b/spec/vcr/Docker_Image/_run/when_the_argument_is_nil/command_configured_in_image/should_normally_show_result_if_image_has_Cmd_configured.yml
@@ -1,0 +1,151 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://unix/v1.4/containers/create
+    body:
+      encoding: UTF-8
+      string: ! '{"Cmd":["true"],"Image":"base"}'
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.6.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: ''
+    headers:
+      !binary "Q29udGVudC1UeXBl":
+      - !binary |-
+        YXBwbGljYXRpb24vanNvbg==
+      !binary "Q29udGVudC1MZW5ndGg=":
+      - !binary |-
+        MTM1
+      !binary "RGF0ZQ==":
+      - !binary |-
+        VHVlLCAyOSBPY3QgMjAxMyAyMjowMDozMyBHTVQ=
+    body:
+      encoding: US-ASCII
+      string: ! '{"Id":"290845cce7ec","Warnings":["Docker detected local DNS server
+        on resolv.conf. Using default external servers: [8.8.8.8 8.8.4.4]"]}'
+    http_version:
+  recorded_at: Tue, 29 Oct 2013 22:00:33 GMT
+- request:
+    method: post
+    uri: http://unix/v1.4/commit?container=290845cc
+    body:
+      encoding: UTF-8
+      string: ! '{"Cmd":["pwd"]}'
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.6.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: ''
+    headers:
+      !binary "Q29udGVudC1UeXBl":
+      - !binary |-
+        YXBwbGljYXRpb24vanNvbg==
+      !binary "Q29udGVudC1MZW5ndGg=":
+      - !binary |-
+        MjE=
+      !binary "RGF0ZQ==":
+      - !binary |-
+        VHVlLCAyOSBPY3QgMjAxMyAyMjowMDozMyBHTVQ=
+    body:
+      encoding: US-ASCII
+      string: ! '{"Id":"3d74951a6e7d"}'
+    http_version:
+  recorded_at: Tue, 29 Oct 2013 22:00:33 GMT
+- request:
+    method: post
+    uri: http://unix/v1.4/containers/create
+    body:
+      encoding: UTF-8
+      string: ! '{"Image":"3d74951a6e7d"}'
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.6.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: ''
+    headers:
+      !binary "Q29udGVudC1UeXBl":
+      - !binary |-
+        YXBwbGljYXRpb24vanNvbg==
+      !binary "Q29udGVudC1MZW5ndGg=":
+      - !binary |-
+        MTM1
+      !binary "RGF0ZQ==":
+      - !binary |-
+        VHVlLCAyOSBPY3QgMjAxMyAyMjowMDozMyBHTVQ=
+    body:
+      encoding: US-ASCII
+      string: ! '{"Id":"7a362a381f09","Warnings":["Docker detected local DNS server
+        on resolv.conf. Using default external servers: [8.8.8.8 8.8.4.4]"]}'
+    http_version:
+  recorded_at: Tue, 29 Oct 2013 22:00:33 GMT
+- request:
+    method: post
+    uri: http://unix/v1.4/containers/7a362a381f09/start
+    body:
+      encoding: UTF-8
+      string: ! '{}'
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.6.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 204
+      message: ''
+    headers:
+      !binary "Q29udGVudC1UeXBl":
+      - !binary |-
+        dGV4dC9wbGFpbjsgY2hhcnNldD11dGYtOA==
+      !binary "Q29udGVudC1MZW5ndGg=":
+      - !binary |-
+        MA==
+      !binary "RGF0ZQ==":
+      - !binary |-
+        VHVlLCAyOSBPY3QgMjAxMyAyMjowMDozMyBHTVQ=
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version:
+  recorded_at: Tue, 29 Oct 2013 22:00:33 GMT
+- request:
+    method: post
+    uri: http://unix/v1.4/containers/7a362a381f09/attach?stdout=true&stream=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.6.0
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      !binary "Q29udGVudC1UeXBl":
+      - !binary |-
+        YXBwbGljYXRpb24vdm5kLmRvY2tlci5yYXctc3RyZWFt
+    body:
+      encoding: US-ASCII
+      string: ! '/
+
+'
+    http_version:
+  recorded_at: Tue, 29 Oct 2013 22:00:33 GMT
+recorded_with: VCR 2.6.0

--- a/spec/vcr/Docker_Image/_run/when_the_argument_is_nil/no_command_configured_in_image/should_raise_an_error_if_no_command_is_specified.yml
+++ b/spec/vcr/Docker_Image/_run/when_the_argument_is_nil/no_command_configured_in_image/should_raise_an_error_if_no_command_is_specified.yml
@@ -1,0 +1,68 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://unix/v1.4/images/create?fromImage=base
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.6.0
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      !binary "Q29udGVudC1UeXBl":
+      - !binary |-
+        YXBwbGljYXRpb24vanNvbg==
+      !binary "RGF0ZQ==":
+      - !binary |-
+        VHVlLCAyOSBPY3QgMjAxMyAyMTo1OTozMCBHTVQ=
+      !binary "VHJhbnNmZXItRW5jb2Rpbmc=":
+      - !binary |-
+        Y2h1bmtlZA==
+    body:
+      encoding: US-ASCII
+      string: ! '{"status":"Pulling repository base"}{"error":"Get https://index.docker.io/v1/images/base/ancestry:
+        lookup index.docker.io: Temporary failure in name resolution","errorDetail":{"message":"Get
+        https://index.docker.io/v1/images/base/ancestry: lookup index.docker.io: Temporary
+        failure in name resolution"}}'
+    http_version:
+  recorded_at: Tue, 29 Oct 2013 22:00:33 GMT
+- request:
+    method: post
+    uri: http://unix/v1.4/containers/create
+    body:
+      encoding: UTF-8
+      string: ! '{"Image":"base"}'
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.6.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 500
+      message: ''
+    headers:
+      !binary "Q29udGVudC1UeXBl":
+      - !binary |-
+        dGV4dC9wbGFpbjsgY2hhcnNldD11dGYtOA==
+      !binary "Q29udGVudC1MZW5ndGg=":
+      - !binary |-
+        MjE=
+      !binary "RGF0ZQ==":
+      - !binary |-
+        VHVlLCAyOSBPY3QgMjAxMyAyMjowMDozMyBHTVQ=
+    body:
+      encoding: US-ASCII
+      string: ! 'No command specified
+
+'
+    http_version:
+  recorded_at: Tue, 29 Oct 2013 22:00:33 GMT
+recorded_with: VCR 2.6.0


### PR DESCRIPTION
I was unable to use the api to do what the commit command line can do, which was to save the config for a run (command/ports et al.). According to the API this is possible by passing run as a query option, but has to be passed as the body of the POST, which this pull request fixes
