### PR TITLE
Splits the lines, and uses the last one that is successfully built

### DIFF
--- a/lib/docker/util.rb
+++ b/lib/docker/util.rb
@@ -32,8 +32,8 @@ module Docker::Util
   end
 
   def extract_id(body)
-    body.lines.each do |line|
-      if (id = line.match(/^Successfully built ([a-f0-9]+)$/)) && !id[1].empty?
+    body.lines.to_a.reverse.each do |line|
+      if (id = line.match(/Successfully built ([a-f0-9]+)/)) && !id[1].empty?
         return id[1]
       end
     end


### PR DESCRIPTION
@bfulton @nahiluhmot @adamjt @wader

Wader had a better implementation of our extract_id since it was only looking at the last line.

For me, extract ID is getting confused with \n at the beginning and \r at the end of the line and not matching.  Since the lines are broken down now anyway, no reason to use the ^ or $.

This should find the last image successfully built in the body.
