### PR TITLE
Log API calls on debug log level

### DIFF
--- a/lib/docker/connection.rb
+++ b/lib/docker/connection.rb
@@ -35,7 +35,7 @@ class Docker::Connection
   def request(*args, &block)
     request = compile_request_params(*args, &block)
     if Docker.logger
-      Docker.logger.info(
+      Docker.logger.debug(
         [request[:method], request[:path], request[:query], request[:body]]
       )
     end


### PR DESCRIPTION
In order to tie logging back into kitchen-docker, this should probably
be at debug loglevel.
