### PR TITLE
Added :timeout parameter to Container#attach

### DIFF
--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -50,7 +50,10 @@ class Docker::Container
 
   # Attach to a container's standard streams / logs.
   def attach(options = {}, &block)
-    opts = { :read_timeout => options.delete(:timeout) }
+    opts = {}
+    if  options.has_key? :timeout
+      opts[:read_timeout] = options.delete(:timeout)
+    end
 
     query = {
       :stream => true, :stdout => true, :stderr => true


### PR DESCRIPTION
I found no way to set a timeout for task running in a container if I tried to attach to it using `Container#attach`. So I added the `:timeout` parameter to the `#attach` method.
