### PR TITLE
Adding methods for Container and Image attributes

### DIFF
--- a/lib/docker.rb
+++ b/lib/docker.rb
@@ -20,6 +20,7 @@ module Docker
   autoload :Image, 'docker/image'
   autoload :Messages, 'docker/messages'
   autoload :Util, 'docker/util'
+  autoload :Base, 'docker/base'
 
   def default_socket_url
     'unix:///var/run/docker.sock'

--- a/lib/docker/base.rb
+++ b/lib/docker/base.rb
@@ -1,0 +1,24 @@
+# This class is a base class for Docker Container and Image.
+# It is implementing accessor methods for the models attributes.
+class Docker::Base
+  include Docker::Error
+
+  attr_accessor :connection, :info
+  attr_reader :id
+
+  # The private new method accepts a connection and optional id.
+  def initialize(connection, hash={})
+    unless connection.is_a?(Docker::Connection)
+      raise ArgumentError, "Expected a Docker::Connection, got: #{connection}."
+    end
+    normalize_hash(hash)
+    @connection, @info, @id = connection, hash, hash['id']
+    raise ArgumentError, "Must have id, got: #{hash}" unless @id
+  end
+
+  # The docker-api will some time return "ID" other times it will return "Id"
+  # and other times it will return "id". This method normalize it to "id"
+  def normalize_hash(hash)
+    hash["id"] ||= hash.delete("ID") || hash.delete("Id")
+  end
+end

--- a/spec/docker/container_spec.rb
+++ b/spec/docker/container_spec.rb
@@ -4,7 +4,9 @@ require 'spec_helper'
 # Docker daemon and have the base Image pulled.
 describe Docker::Container do
   describe '#to_s' do
-    subject { described_class.send(:new, Docker.connection, rand(10000).to_s) }
+    subject {
+      described_class.send(:new, Docker.connection, 'id' => rand(10000).to_s)
+    }
 
     let(:id) { 'bf119e2' }
     let(:connection) { Docker.connection }

--- a/spec/docker/image_spec.rb
+++ b/spec/docker/image_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 
 describe Docker::Image do
   describe '#to_s' do
-    subject { described_class.new(Docker.connection, id, info) }
+    subject { described_class.new(Docker.connection, info) }
 
     let(:id) { 'bf119e2' }
     let(:connection) { Docker.connection }
 
     let(:info) do
-      {"Repository" => "base", "Tag" => "latest",
+      {"id" => "bf119e2", "Repository" => "base", "Tag" => "latest",
         "Created" => 1364102658, "Size" => 24653, "VirtualSize" => 180116135}
     end
 


### PR DESCRIPTION
Hi,
I am writing a fog (http://fog.io) and foreman (http://theforeman.org) docker support using docker-api gem.
I wanted to expose as much attributes as I could about the images and the containers. In this patch I am implementing method_missing and respond_to? to expose all the model attributes.
Thanks,
  Amos.
