### PR TITLE
FIXES Issue #85 - add support for using the same docker host ENV variabl...

### DIFF
--- a/lib/docker.rb
+++ b/lib/docker.rb
@@ -30,7 +30,12 @@ module Docker
   end
 
   def url
-    @url ||= ENV['DOCKER_URL'] || default_socket_url
+    @url ||= ENV['DOCKER_URL'] || ENV['DOCKER_HOST'] || default_socket_url
+    # docker uses a default notation tcp:// which means tcp://localhost:4243
+    if @url == 'tcp://'
+      @url = 'tcp://localhost:4243'
+    end
+    @url
   end
 
   def options

--- a/spec/docker_spec.rb
+++ b/spec/docker_spec.rb
@@ -5,6 +5,7 @@ describe Docker do
 
   before do
     ENV['DOCKER_URL'] = nil
+    ENV['DOCKER_HOST'] = nil
   end
 
   it { should be_a Module }
@@ -28,6 +29,38 @@ describe Docker do
 
       its(:options) { {} }
       its(:url) { should == 'unixs:///var/run/not-docker.sock' }
+      its(:connection) { should be_a Docker::Connection }
+    end
+
+    context "when the DOCKER_HOST is set and uses default tcp://" do
+      before do
+        ENV['DOCKER_HOST'] = 'tcp://'
+      end
+
+      its(:options) { {} }
+      its(:url) { should == 'tcp://localhost:4243' }
+      its(:connection) { should be_a Docker::Connection }
+    end
+
+    context "when the DOCKER_HOST ENV variables is set" do
+      before do
+        ENV['DOCKER_HOST'] = 'tcp://someserver:8103'
+      end
+
+      its(:options) { {} }
+      its(:url) { should == 'tcp://someserver:8103' }
+      its(:connection) { should be_a Docker::Connection }
+    end
+
+    context "DOCKER_URL should take precedence over DOCKER_HOST" do
+      before do
+        ENV['DOCKER_HOST'] = 'tcp://someserver:8103'
+        ENV['DOCKER_URL'] = 'tcp://someotherserver:8103'
+
+      end
+
+      its(:options) { {} }
+      its(:url) { should == 'tcp://someotherserver:8103' }
       its(:connection) { should be_a Docker::Connection }
     end
   end


### PR DESCRIPTION
See issue #85 for background info.

I also added support to change tcp:// to tcp://localhost:4243 since the docker api doesn't seem to handle a blank url such as tcp:// that docker handles correctly.
