### PR TITLE
make remove/delete consistent between container/image

### DIFF
--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -104,11 +104,12 @@ class Docker::Container
     end
   end
 
-  # delete container
-  def delete(options = {})
+  # remove container
+  def remove(options = {})
     connection.delete("/containers/#{self.id}", options)
     nil
   end
+  alias_method :delete, :remove
 
   def copy(path, &block)
     connection.post(path_for(:copy), {},

--- a/lib/docker/image.rb
+++ b/lib/docker/image.rb
@@ -87,6 +87,7 @@ class Docker::Image
   def remove
     connection.delete("/images/#{self.id}")
   end
+  alias_method :delete, :remove
 
   # Return a String representation of the Image.
   def to_s


### PR DESCRIPTION
PR for #89

To delete a container the method is `Docker::Container#delete`. To delete an image it's `Docker::Image#remove`. The docker API HTTP method for both operations is "DELETE", and the documentation describes both as a remove operation. While I don't think it matters much what the method name is, I do think it should be consistent between both containers and images.

This changes it so that `#remove` is the primary method, with `#delete` as an alias.
