### PR TITLE
Enable registry hostnames with custom port number for push api call

### DIFF
--- a/lib/docker/image.rb
+++ b/lib/docker/image.rb
@@ -22,14 +22,14 @@ class Docker::Image < Docker::Base
 
   # Push the Image to the Docker registry.
   def push(creds = nil, options = {})
-    repository = self.info['RepoTags'].first.split(/:/)[0] rescue nil
+    repository = self.info['RepoTags'].first.match(/(.+):(.+)/) rescue nil
 
     raise ArgumentError, "Image does not have a name to push." unless repository
 
     credentials = creds || Docker.creds
     headers = Docker::Util.build_auth_header(credentials)
     connection.post(
-      "/images/#{repository}/push",
+      "/images/#{repository[1]}/push",
       options,
       :headers => headers
     )


### PR DESCRIPTION
I would like to be able to push images to private docker registry bound on custom port. 
For example: custom.index.io:4999/nahiluhmot/base2:latest
