### PR TITLE
Remove the default read timeout on the Container#wait.

### DIFF
--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -13,8 +13,9 @@ class Docker::Container
     end
   end
 
-  # Wait for the current command to finish executing.
-  def wait(time = 60)
+  # Wait for the current command to finish executing. Default wait time is
+  # `Excon.options[:read_timeout]`.
+  def wait(time = nil)
     resp = connection.post(path_for(:wait), nil, :read_timeout => time)
     Docker::Util.parse_json(resp)
   end


### PR DESCRIPTION
@bfulton 

Setting the default read timeout in this method was yielding unexpected results when setting the read timeout via `Docker.options`. This pull ensures that the default read timeout is used when no argument is given.
