### PR TITLE
Check for Rake::Task before loading rake tasks

### DIFF
--- a/lib/docker.rb
+++ b/lib/docker.rb
@@ -22,7 +22,7 @@ module Docker
   require 'docker/messages'
   require 'docker/util'
   require 'docker/version'
-  require 'docker/rake_task' if defined?(Rake)
+  require 'docker/rake_task' if defined?(Rake::Task)
 
   def default_socket_url
     'unix:///var/run/docker.sock'


### PR DESCRIPTION
Because if `Rake` exists and `Rake::Task` not, loading of `docker/rake_task` crashes.
