### PR TITLE
Allow passing in a custom connection object to authenticate

### DIFF
--- a/lib/docker.rb
+++ b/lib/docker.rb
@@ -74,9 +74,9 @@ module Docker
   end
 
   # Login to the Docker registry.
-  def authenticate!(options = {})
+  def authenticate!(options = {}, conn = connection)
     creds = options.to_json
-    connection.post('/auth', {}, :body => creds)
+    conn.post('/auth', {}, :body => creds)
     @creds = creds
     true
   rescue Docker::Error::ServerError, Docker::Error::UnauthorizedError


### PR DESCRIPTION
this allows multiple docker remote api connections at the same time and is in line with how container and image is interfaced
