### PR TITLE
Send custom signal to container

### DIFF
--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -84,14 +84,22 @@ class Docker::Container
   # return the Container. #start and #kill do the same,
   # but rescue from ServerErrors.
   [:start, :kill].each do |method|
-    define_method(:"#{method}!") do |opts = {}|
-      connection.post(path_for(method), {}, :body => opts.to_json)
-      self
-    end
-
     define_method(method) do |*args|
       begin; public_send(:"#{method}!", *args); rescue ServerError; self end
     end
+  end
+
+  def start(opts = {})
+    connection.post(path_for("start"), {}, :body => opts.to_json)
+    self
+  end
+
+  def kill(opts = {})
+    signal = opts.delete('signal')
+    query = {}
+    query['signal'] = signal if signal
+    connection.post(path_for("kill"), query, :body => opts.to_json)
+    self
   end
 
   # #stop! and #restart! both perform the associated action and


### PR DESCRIPTION
The endpoint /container/:id/kill can take a 'signal' query parameter as defined in

http://docs.docker.io/reference/api/docker_remote_api_v1.11/#21-containers
