### PR TITLE
tar tempfile should be opened in binary mode

### DIFF
--- a/lib/docker/util.rb
+++ b/lib/docker/util.rb
@@ -36,7 +36,7 @@ module Docker::Util
   def create_dir_tar(directory)
     cwd = FileUtils.pwd
     tempfile_name = Dir::Tmpname.create('out') {}
-    tempfile = File.open(tempfile_name, 'w+')
+    tempfile = File.open(tempfile_name, 'wb+')
     FileUtils.cd(directory)
     Archive::Tar::Minitar.pack('.', tempfile)
     File.new(tempfile.path, 'r')


### PR DESCRIPTION
@tlunter this add binary mode back to the directory tar archive temp file.  See #149.
