### PR TITLE
Docker can make requests to other API versions

### DIFF
--- a/lib/docker.rb
+++ b/lib/docker.rb
@@ -61,6 +61,11 @@ module Docker
     reset_connection!
   end
 
+  def api_version=(new_version)
+    options[:api_version] = new_version
+    reset_connection!
+  end
+
   def connection
     @connection ||= Connection.new(url, options)
   end
@@ -99,7 +104,7 @@ module Docker
   end
 
   module_function :default_socket_url, :env_url, :url, :url=, :options,
-                  :options=, :creds, :creds=, :logger, :logger=,
+                  :options=, :api_version=, :creds, :creds=, :logger, :logger=,
                   :connection, :reset_connection!, :version, :info,
                   :authenticate!, :validate_version!
 end

--- a/lib/docker/connection.rb
+++ b/lib/docker/connection.rb
@@ -16,6 +16,7 @@ class Docker::Connection
       raise ArgumentError, "Expected a Hash, got: '#{opts}'"
     else
       uri = URI.parse(url)
+      @api_version = opts.delete(:api_version) || Docker::API_VERSION
       if uri.scheme == "unix"
         @url, @options = 'unix:///', {:socket => uri.path}.merge(opts)
       else
@@ -72,7 +73,7 @@ private
     user_agent = "Swipely/Docker-API #{Docker::VERSION}"
     {
       :method        => http_method,
-      :path          => "/v#{Docker::API_VERSION}#{path}",
+      :path          => "/v#{@api_version}#{path}",
       :query         => query,
       :headers       => { 'Content-Type' => content_type,
                           'User-Agent'   => user_agent,

--- a/spec/docker_spec.rb
+++ b/spec/docker_spec.rb
@@ -88,6 +88,21 @@ describe Docker do
     end
   end
 
+  describe "#api_version=" do
+
+    let(:version) { 'foo' }
+
+    it 'calls #reset_connection!' do
+      expect(subject).to receive(:reset_connection!)
+      subject.api_version = version
+    end
+
+    it 'sets the version on connection' do
+      subject.api_version = version
+      subject.options[:api_version].should eq version
+    end
+  end
+
   describe '#version' do
     before do
       subject.url = nil


### PR DESCRIPTION
Sometimes is useful to have the last version of this gem, but the target DOCKER_HOST could be outdated.

Setting the API version in the Docker:

```
Docker.api_version = "1.10"
Docker.version
```

will make the request to `/v1.10/version`. This will allow checking for older versions of the Docker daemon and either fail gracefully or use a reduced set of the API (for instance, no `pause`/`unpause` before v.1.12).

Currently, trying to talk to a outdated Docker daemon results in a non-informative error.
