### PR TITLE
Allow for overriding connection for version + info

### DIFF
--- a/lib/docker.rb
+++ b/lib/docker.rb
@@ -70,12 +70,12 @@ module Docker
   end
 
   # Get the version of Go, Docker, and optionally the Git commit.
-  def version
+  def version(connection = self.connection)
     Util.parse_json(connection.get('/version'))
   end
 
   # Get more information about the Docker server.
-  def info
+  def info(connection = self.connection)
     Util.parse_json(connection.get('/info'))
   end
 


### PR DESCRIPTION
Currently, connection is hardwired for version and info, this allows you to provide a custom connection object for the purpose of dealing with multiple servers, defaulting to the self.connection if this isn't provided.
