### PR TITLE
Docker requires DOCKER_HOST env to use format localhost:3000 without the scheme

### DIFF
--- a/lib/docker/connection.rb
+++ b/lib/docker/connection.rb
@@ -16,7 +16,9 @@ class Docker::Connection
       raise ArgumentError, "Expected a Hash, got: '#{opts}'"
     else
       uri = URI.parse(url)
-      if uri.scheme == "unix"
+      if uri.host.nil? && uri.port.nil? && url.match(/\w+\:\d+/)
+        @url, @options = "http://#{uri}", opts
+      elsif uri.scheme == "unix"
         @url, @options = 'unix:///', {:socket => uri.path}.merge(opts)
       else
         @url, @options = url, opts

--- a/spec/docker/connection_spec.rb
+++ b/spec/docker/connection_spec.rb
@@ -41,6 +41,24 @@ describe Docker::Connection do
         end
       end
     end
+
+    context 'url conversion to uri' do
+      context 'when the url follows the Docker convention for DOCKER_HOST and does not contain a scheme' do
+        let(:url) { 'localhost:4243' }
+
+        it 'adds the scheme to the url' do
+          expect(subject.url).to eq "http://#{url}"
+        end
+      end
+
+      context 'when the url is a complete uri' do
+        let(:url) { 'http://localhost:4243' }
+
+        it 'leaves the url intact' do
+          expect(subject.url).to eq url
+        end
+      end
+    end
   end
 
   describe '#resource' do


### PR DESCRIPTION
This commit allows a URL to be used that does not contain a scheme.  If detected, the default scheme of `http://` is added.

Example:

Including the scheme in the environment causes Docker to fail
`$ DOCKER_HOST=http://localhost:4243 docker version
2014/08/06 13:02:29 Invalid bind address protocol: http://localhost:4243`

It works fine with just:
`$ DOCKER_HOST=localhost:4243 docker version`

Excluding the scheme currently with Docker API causes Docker API to fail

```
$ DOCKER_HOST=localhost:4243 bundle exec ruby -e "require './lib/docker'; puts Docker::Container.all.length"
/Users/matthew/.rbenv/versions/2.0.0-p481/lib/ruby/gems/2.0.0/gems/excon-0.39.3/lib/excon/connection.rb:88:in `initialize': no implicit conversion of nil into String (TypeError)
    from /Users/matthew/.rbenv/versions/2.0.0-p481/lib/ruby/gems/2.0.0/gems/excon-0.39.3/lib/excon.rb:123:in `new'
    from /Users/matthew/.rbenv/versions/2.0.0-p481/lib/ruby/gems/2.0.0/gems/excon-0.39.3/lib/excon.rb:123:in `new'
    from /Users/matthew/Projects/Ably/forks/docker-api/lib/docker/connection.rb:30:in `resource'
    from /Users/matthew/Projects/Ably/forks/docker-api/lib/docker/connection.rb:42:in `request'
    from /Users/matthew/Projects/Ably/forks/docker-api/lib/docker/connection.rb:57:in `block (2 levels) in <class:Connection>'
    from /Users/matthew/Projects/Ably/forks/docker-api/lib/docker/container.rb:187:in `all'
    from -e:1:in `<main>'
```

Now with this PR landed, you get the following

```
$ DOCKER_HOST=localhost:4243 bundle exec ruby -e "require './lib/docker'; puts Docker::Container.all.length"
# => 1
```
