### PR TITLE
expose Image.get in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ image.run('ls -l')
 image.remove(:force => true)
 # => true
 
+# Get Image from the server, with id
+Docker::Image.get('df4f1bdecf40')
+
 # Given a Container's export, creates a new Image.
 Docker::Image.import('some-export.tar')
 # => Docker::Image { :id => 66b712aef, :connection => Docker::Connection { :url => http://localhost, :options => {:port=>4243} } }


### PR DESCRIPTION
Make it so I don't have to look through the source to find the function I am looking for.
