### PR TITLE
ServerError returns Server Response Message

### DIFF
--- a/lib/docker/connection.rb
+++ b/lib/docker/connection.rb
@@ -49,7 +49,7 @@ class Docker::Connection
   rescue Excon::Errors::NotFound => ex
     raise NotFoundError, ex.message
   rescue Excon::Errors::InternalServerError => ex
-    raise ServerError, ex.message
+    raise ServerError, ex.response.data[:body]
   rescue Excon::Errors::Timeout => ex
     raise TimeoutError, ex.message
   end


### PR DESCRIPTION
I got tired of receiving unhelpful errors back from this library (which is still awesome).  So, after screwing around with the response hash for Excon (:debug_response => true) which I didn't much care for, I think this is much better, and behaves in a manner that reflects the docker cli perfectly.

This is what I would get before in the Error message:
`Expected([200, 201, 202, 203, 204, 304]) <=> Actual(500 InternalServerError)`

This is what I get now (in this example, of course, the host already had port 81 allocated):
`Cannot start container 47a0ac2ef963e9f44d34baa7fc0c63886fdd310e9cfb5ba0ea26c4616a2caf88: Bind for 0.0.0.0:81 failed: port is already allocated`

This is tested on API v1.14

```
2.1.1 :007 > ap Docker.version
{
       "ApiVersion" => "1.14",
             "Arch" => "amd64",
        "GitCommit" => "fa7b24f",
        "GoVersion" => "go1.3.1",
    "KernelVersion" => "3.16.1-tinycore64",
               "Os" => "linux",
          "Version" => "1.2.0"
}
```
