### PR TITLE
Allow Docker#authenticate! to call other hosts

### DIFF
--- a/lib/docker.rb
+++ b/lib/docker.rb
@@ -80,7 +80,7 @@ module Docker
   end
 
   # Login to the Docker registry.
-  def authenticate!(options = {})
+  def authenticate!(options = {}, connection = connection)
     creds = options.to_json
     connection.post('/auth', {}, :body => creds)
     @creds = creds


### PR DESCRIPTION
Currently Docker#authenticate! is scoped only to a single connection. This PR addresses this to allow multi-host environments to authenticate whilst remaining API-compatible with the existing implementation for backward compatibility.
