### PR TITLE
Fix excon warning

### DIFF
--- a/lib/excon/middlewares/hijack.rb
+++ b/lib/excon/middlewares/hijack.rb
@@ -1,6 +1,6 @@
 module Excon
   VALID_REQUEST_KEYS << :hijack_block
-  
+
   module Middleware
     # Hijack is an Excon middleware which parses response headers and then
     # yields the underlying TCP socket for raw TCP communication (used to


### PR DESCRIPTION
This PR fixes https://github.com/swipely/docker-api/issues/179 by adding `:hijack_block` to the list of allowed keys.
