### PR TITLE
Raise Docker::Error for 304s

### DIFF
--- a/lib/docker/connection.rb
+++ b/lib/docker/connection.rb
@@ -52,6 +52,8 @@ class Docker::Connection
     raise ServerError, ex.response.data[:body]
   rescue Excon::Errors::Timeout => ex
     raise TimeoutError, ex.message
+  rescue Excon::Errors::NotModified => ex
+    raise NotModifiedError, ex.message
   end
 
   # Delegate all HTTP methods to the #request.

--- a/spec/docker/container_spec.rb
+++ b/spec/docker/container_spec.rb
@@ -221,6 +221,13 @@ describe Docker::Container do
       expect(all.map(&:id)).to be_any { |id| id.start_with?(subject.id) }
       expect(subject.wait(10)['StatusCode']).to be_zero
     end
+
+    context 'when the container is already stopped' do
+      it 'raises an error' do
+        expect { subject.start }
+        .to raise_error(Docker::Error::NotModifiedError)
+      end
+    end
   end
 
   describe '#stop' do
@@ -235,6 +242,13 @@ describe Docker::Container do
       expect(described_class.all.map(&:id)).to be_none { |id|
         id.start_with?(subject.id)
       }
+    end
+
+    context 'when the container is already stopped' do
+      it 'raises an error', :vcr do
+        expect { subject.stop }
+        .to raise_error(Docker::Error::NotModifiedError)
+      end
     end
   end
 


### PR DESCRIPTION
Docker API now returns 304 to identify redundant operations, without this patch the Excon error will be returned directly and users won't be able to catch `Docker::Error` as a generic error.

I'm not certain specs pass, if someone could throw me a helping hand with vcr (or the tests themselves) I'd appreciate it.
