### PR TITLE
Fix Docker::Image.create when `m` is nil

### DIFF
--- a/lib/docker/image.rb
+++ b/lib/docker/image.rb
@@ -99,8 +99,9 @@ class Docker::Image
       headers = !credentials.nil? && Docker::Util.build_auth_header(credentials)
       headers ||= {}
       body = conn.post('/images/create', opts, :headers => headers)
-      id = Docker::Util.fix_json(body).select { |m| m['id'] }.last['id']
-      new(conn, 'id' => id, :headers => headers)
+      json = Docker::Util.fix_json(body)
+      image = json.reverse_each.find { |el| el && el.key?('id') }
+      new(conn, 'id' => image && image.fetch('id'), :headers => headers)
     end
 
     # Return a specific image.


### PR DESCRIPTION
Sometime when pulling for second time the API responds
with nil somewhere, leading to:

```
   undefined method `[]' for nil:NilClass
 # /var/lib/gems/2.1.0/gems/docker-api-1.13.7/lib/docker/image.rb:102:in `create'
```
