### PR TITLE
Subclasses are honored

### DIFF
--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -79,12 +79,19 @@ class Docker::Container
     hash = Docker::Util.parse_json(connection.post('/commit',
                                                    options,
                                                    :body => config.to_json))
-    Docker::Image.send(:new, self.connection, hash)
+    _create_image(self.connection, hash)
   end
+
+  # allows subclasses to delegate to their own friends
+  def _create_image(cnxn, hash)
+    Docker::Image.send(:new, cnxn, hash)
+  end
+  private :_create_image
 
   # Return a String representation of the Container.
   def to_s
-    "Docker::Container { :id => #{self.id}, :connection => #{self.connection} }"
+    "#{self.class.name} { :id => #{self.id}, "\
+      ":connection => #{self.connection} }"
   end
 
   # #json returns information about the Container, #changes returns a list of

--- a/lib/docker/image.rb
+++ b/lib/docker/image.rb
@@ -10,7 +10,7 @@ class Docker::Image
     opts = { 'Image' => self.id }
     opts["Cmd"] = cmd.is_a?(String) ? cmd.split(/\s+/) : cmd
     begin
-      Docker::Container.create(opts, connection)
+      _create_container(opts, connection)
                        .tap(&:start!)
     rescue ServerError => ex
       if cmd
@@ -20,6 +20,12 @@ class Docker::Image
       end
     end
   end
+
+  # allows subclasses to delegate to their own friends
+  def _create_container(opts, connection)
+    Docker::Container.create(opts, connection)
+  end
+  private :_create_container
 
   # Push the Image to the Docker registry.
   def push(creds = nil, options = {})
@@ -69,7 +75,7 @@ class Docker::Image
 
   # Return a String representation of the Image.
   def to_s
-    "Docker::Image { :id => #{self.id}, :info => #{self.info.inspect}, "\
+    "#{self.class.name} { :id => #{self.id}, :info => #{self.info.inspect}, "\
       ":connection => #{self.connection} }"
   end
 
@@ -83,7 +89,7 @@ class Docker::Image
 
   # Update the @info hash, which is the only mutable state in this object.
   def refresh!
-    img = Docker::Image.all(:all => true).find { |image|
+    img = self.class.all(:all => true).find { |image|
       image.id.start_with?(self.id) || self.id.start_with?(image.id)
     }
     info.merge!(self.json)


### PR DESCRIPTION
These are fairly trivial changes to allow subclasses to walk proud and tall as first-class citizens.
- to_s prints the actual class name
- calls go to eg. self.class not Docker::Image
- Images creating containers and containers creating images go through a private method stub that subclasses can override (allowing MyAwesomeImage < Docker::Image to create a MyAwesomeContainer if appropriate)
