### PR TITLE
Push and Pull send progress steps to supplied block; pushing raises an error if unauthorized.

### DIFF
--- a/spec/docker/image_spec.rb
+++ b/spec/docker/image_spec.rb
@@ -142,8 +142,9 @@ describe Docker::Image do
       }
     }
     let(:repo_tag) { "#{ENV['DOCKER_API_USER']}/true" }
+    let(:build_script) { "FROM tianon/true\nENV TRIVIAL CHANGE\n" }
     let(:image) {
-      described_class.build("FROM tianon/true\n", "t" => repo_tag).refresh!
+      described_class.build(build_script, "t" => repo_tag).refresh!
     }
     after { image.remove(:name => repo_tag, :noprune => true) }
 
@@ -157,13 +158,13 @@ describe Docker::Image do
 
     context 'when the image was retrived by get' do
       let(:image) {
-        described_class.build("FROM tianon/true\n", "t" => repo_tag).refresh!
+        described_class.build(build_script, "t" => repo_tag).refresh!
         described_class.get(repo_tag)
       }
 
       context 'when no tag is specified' do
         it 'looks up the first repo tag', :vcr do
-          expect { image.push }.to_not raise_error
+          expect { image.push(credentials) }.to_not raise_error
         end
       end
     end

--- a/spec/vcr/Docker_Image/_create/calls_back_to_a_supplied_block.yml
+++ b/spec/vcr/Docker_Image/_create/calls_back_to_a_supplied_block.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<DOCKER_HOST>/v1.15/images/create?fromImage=swipely%2Fscratch"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - text/plain
+      X-Registry-Auth:
+      - eyJ1c2VybmFtZSI6InRkdWZmaWVsZCIsInBhc3N3b3JkIjoiaTlCZj5KZ3ZmYmpZL3NKV01jVTkiLCJlbWFpbCI6ImdpdGh1YkB0b21kdWZmaWVsZC5jb20ifQ==
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Dec 2014 18:08:52 GMT
+    body:
+      encoding: UTF-8
+      string: "{\"status\":\"Pulling repository swipely/scratch\"}\r\n{\"status\":\"Pulling
+        image (latest) from swipely/scratch\",\"progressDetail\":{},\"id\":\"511136ea3c5a\"}{\"status\":\"Pulling
+        image (latest) from swipely/scratch, endpoint: https://registry-1.docker.io/v1/\",\"progressDetail\":{},\"id\":\"511136ea3c5a\"}{\"status\":\"Pulling
+        dependent layers\",\"progressDetail\":{},\"id\":\"511136ea3c5a\"}{\"status\":\"Download
+        complete\",\"progressDetail\":{},\"id\":\"511136ea3c5a\"}{\"status\":\"Download
+        complete\",\"progressDetail\":{},\"id\":\"511136ea3c5a\"}{\"status\":\"Status:
+        Image is up to date for swipely/scratch\"}\r\n"
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:54 GMT
+- request:
+    method: delete
+    uri: "<DOCKER_HOST>/v1.15/images/swipely/scratch?noprune=true"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Dec 2014 18:08:54 GMT
+      Content-Length:
+      - '40'
+    body:
+      encoding: UTF-8
+      string: |-
+        [{"Untagged":"swipely/scratch:latest"}
+        ]
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:54 GMT
+recorded_with: VCR 2.9.3

--- a/spec/vcr/Docker_Image/_create/raises_an_error_if_not_found.yml
+++ b/spec/vcr/Docker_Image/_create/raises_an_error_if_not_found.yml
@@ -1,0 +1,32 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<DOCKER_HOST>/v1.15/images/create?fromImage=swipely%2Fnonesuchimage"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - text/plain
+      X-Registry-Auth:
+      - eyJ1c2VybmFtZSI6InRkdWZmaWVsZCIsInBhc3N3b3JkIjoiaTlCZj5KZ3ZmYmpZL3NKV01jVTkiLCJlbWFpbCI6ImdpdGh1YkB0b21kdWZmaWVsZC5jb20ifQ==
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Dec 2014 18:08:52 GMT
+    body:
+      encoding: UTF-8
+      string: "{\"status\":\"Pulling repository swipely/nonesuchimage\"}\r\n{\"errorDetail\":{\"message\":\"Error:
+        image swipely/nonesuchimage not found\"},\"error\":\"Error: image swipely/nonesuchimage
+        not found\"}\r\n"
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:54 GMT
+recorded_with: VCR 2.9.3

--- a/spec/vcr/Docker_Image/_push/calls_back_to_a_supplied_block.yml
+++ b/spec/vcr/Docker_Image/_push/calls_back_to_a_supplied_block.yml
@@ -1,0 +1,276 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<DOCKER_HOST>/v1.15/build?t=<USERNAME>%2Ftrue"
+    body:
+      encoding: UTF-8
+      string: !binary |-
+        RG9ja2VyZmlsZQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAADAwMDA2NDAAMDAwMDAwMAAwMDAwMDAwADAwMDAwMDAwMDIx
+        ADEyNDM3MTI3MjU0ADAxMzMwNAAgMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB1c3RhcgAwMHdoZWVs
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAd2hlZWwAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAwMDAwMDAwADAwMDAwMDAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAABGUk9NIHRpYW5vbi90cnVlCgAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Dec 2014 18:08:44 GMT
+    body:
+      encoding: UTF-8
+      string: "{\"stream\":\"Step 0 : FROM tianon/true\\n\"}\r\n{\"stream\":\" ---\\u003e
+        69e7aca3d78e\\n\"}\r\n{\"stream\":\"Step 1 : ENV TRIVIAL CHANGE\\n\"}\r\n{\"stream\":\"
+        ---\\u003e Running in 6d0c01400c38\\n\"}\r\n{\"stream\":\" ---\\u003e b239f80471db\\n\"}\r\n{\"stream\":\"Removing
+        intermediate container 6d0c01400c38\\n\"}\r\n{\"stream\":\"Successfully built
+        b239f80471db\\n\"}\r\n"
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:44 GMT
+- request:
+    method: get
+    uri: "<DOCKER_HOST>/v1.15/images/json?all=true"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Dec 2014 18:08:44 GMT
+    body:
+      encoding: UTF-8
+      string: |-
+        [{"Created":1418178761,"Id":"b239f80471dbc0ee17ca34e648e4cc0b1013c740bccb621d6ad00edbc3f26dc7","ParentId":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","RepoTags":["<USERNAME>/true:latest"],"Size":0,"VirtualSize":125}
+        ,{"Created":1417805428,"Id":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","ParentId":"9d182a4ffb01e4ecfc5397bf9a989016e7ae6920f6e64a037db4c0a2f3c0e264","RepoTags":["tianon/true:latest"],"Size":0,"VirtualSize":125}
+        ,{"Created":1416799251,"Id":"0b7a3c1fbea815d721ccf5404d05e0d8c667945ebe21acdf530fae3aa22184ce","ParentId":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":125,"VirtualSize":125}
+        ,{"Created":1415864019,"Id":"74f5b38a45c97043cdf0082b8e8dd002497ab6b03388cdb2f20bafb7468ad55b","ParentId":"31ae66be94f160a92e1e757ab9a66aa7183af55183080576fb93a52cbce9e0cd","RepoTags":["registry:0.9.0"],"Size":0,"VirtualSize":411649756}
+        ,{"Created":1415864018,"Id":"31ae66be94f160a92e1e757ab9a66aa7183af55183080576fb93a52cbce9e0cd","ParentId":"b3fd13d94685095ec1c1f8f0f371dde8be9a21f8f457d4d10e5ad72042a152af","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649756}
+        ,{"Created":1415864017,"Id":"eae8be82bb623181222558e4df0dd59c943cdc2fd3c4e41de669e4bd35a866e6","ParentId":"8eae38b276496440046cd9f545c24533e692cbed6fd1bc4e29a7af5e4ae72a61","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649756}
+        ,{"Created":1415864017,"Id":"b3fd13d94685095ec1c1f8f0f371dde8be9a21f8f457d4d10e5ad72042a152af","ParentId":"eae8be82bb623181222558e4df0dd59c943cdc2fd3c4e41de669e4bd35a866e6","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649756}
+        ,{"Created":1415864016,"Id":"8eae38b276496440046cd9f545c24533e692cbed6fd1bc4e29a7af5e4ae72a61","ParentId":"16b02bf8dc3d1f70e098cbd968f154468fcf41be6bf59b24a35b4fdded3edbca","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":50796,"VirtualSize":411649756}
+        ,{"Created":1415864015,"Id":"16b02bf8dc3d1f70e098cbd968f154468fcf41be6bf59b24a35b4fdded3edbca","ParentId":"b22cb7ed5ccbeeaf2a67d5d3034a308c6eedf2ccb247851c9a14c05b441716fa","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":23990121,"VirtualSize":411598960}
+        ,{"Created":1415863862,"Id":"b22cb7ed5ccbeeaf2a67d5d3034a308c6eedf2ccb247851c9a14c05b441716fa","ParentId":"8b170afd480f41a84331dcaabfa6465769205e645ba13f8baa085f1f68e4f1cf","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":11550557,"VirtualSize":387608839}
+        ,{"Created":1415863855,"Id":"8b170afd480f41a84331dcaabfa6465769205e645ba13f8baa085f1f68e4f1cf","ParentId":"8dda8bb23254979ce24f2ca4d7115f4563a9ae4f0e774b2d419318d81a5c720d","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":73,"VirtualSize":376058282}
+        ,{"Created":1415863853,"Id":"8dda8bb23254979ce24f2ca4d7115f4563a9ae4f0e774b2d419318d81a5c720d","ParentId":"7d49ba12f2de52ae8dfec8c661f4471e00d546b57adc3913cefc56f89b932e22","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1880042,"VirtualSize":376058209}
+        ,{"Created":1415863849,"Id":"d9925ba888d4dba2d9b22273d261155fe3b2a4e6cfa5db44e4abe5ac8e311efa","ParentId":"4abfff610473315c2fb7a6278c924948ba877fe6630ad197f734572b7636188e","RepoTags":["registry:0.8.1"],"Size":0,"VirtualSize":430388853}
+        ,{"Created":1415863848,"Id":"4abfff610473315c2fb7a6278c924948ba877fe6630ad197f734572b7636188e","ParentId":"8b840022b4b5d60e0f66d7f72b992eb5b52e75dfdf1b8e9535d85df57236e7f5","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":430388853}
+        ,{"Created":1415863847,"Id":"8b840022b4b5d60e0f66d7f72b992eb5b52e75dfdf1b8e9535d85df57236e7f5","ParentId":"11d3a913c69b0ea1c7d0df3708dfa8c789b68dc0884471cf862de1160c7eaaba","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":430388853}
+        ,{"Created":1415863846,"Id":"11d3a913c69b0ea1c7d0df3708dfa8c789b68dc0884471cf862de1160c7eaaba","ParentId":"ae88728b911af97e928890b1c3b7b34dd25fb313f3b20cd73e532e2903d3d3b9","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":430388853}
+        ,{"Created":1415863845,"Id":"ae88728b911af97e928890b1c3b7b34dd25fb313f3b20cd73e532e2903d3d3b9","ParentId":"16c101215b54ac2210fa62d54e0893323ae43e3d33b75119b1246a9dbbc1c7cf","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":23901352,"VirtualSize":430388853}
+        ,{"Created":1415863690,"Id":"16c101215b54ac2210fa62d54e0893323ae43e3d33b75119b1246a9dbbc1c7cf","ParentId":"4c86ccffaf465d6688815f844bfadbb91a76df42043e629d208c5b75de31b891","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":8442747,"VirtualSize":406487501}
+        ,{"Created":1415863686,"Id":"4c86ccffaf465d6688815f844bfadbb91a76df42043e629d208c5b75de31b891","ParentId":"e930198c27c4d790fd3eece5212c7ab1e6f272bfd21061c877b38696aa91ac27","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":73,"VirtualSize":398044754}
+        ,{"Created":1415863685,"Id":"e930198c27c4d790fd3eece5212c7ab1e6f272bfd21061c877b38696aa91ac27","ParentId":"6ffb25246d5531cdbf15ac250dcf0d10fca544944eaf7386b4cff8577488f258","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1861177,"VirtualSize":398044681}
+        ,{"Created":1415863681,"Id":"7e2db37c6564bf030e6c5af9725bf9f9a8196846e3a77a51e201fc97871e2e60","ParentId":"765d6041baaa23390504094a101b8f4e3433e99a03cb0f5cf20e3b2e3a2a7523","RepoTags":["registry:latest"],"Size":0,"VirtualSize":411649320}
+        ,{"Created":1415863680,"Id":"765d6041baaa23390504094a101b8f4e3433e99a03cb0f5cf20e3b2e3a2a7523","ParentId":"c978e4c4261aec2dbc24c84427460afdaeaa64359ff4ed0ad6d4d00f0e0e0cd7","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649320}
+        ,{"Created":1415863680,"Id":"c978e4c4261aec2dbc24c84427460afdaeaa64359ff4ed0ad6d4d00f0e0e0cd7","ParentId":"f846b2ccf2c5679f8d95014285a8e771441b5e5fc04670e0dfcb1242e985eb5e","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649320}
+        ,{"Created":1415863679,"Id":"7949c9f83980aab0ac80e3150c0d3f899556c68f35d8f6f9ca7c79ecb769b70e","ParentId":"e8ca0e3bcd941b41c0c3dabebdb545f8331ddbb25257e6bc2cd3b6e6233d64f5","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":50796,"VirtualSize":411649320}
+        ,{"Created":1415863679,"Id":"f846b2ccf2c5679f8d95014285a8e771441b5e5fc04670e0dfcb1242e985eb5e","ParentId":"7949c9f83980aab0ac80e3150c0d3f899556c68f35d8f6f9ca7c79ecb769b70e","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649320}
+        ,{"Created":1415863677,"Id":"e8ca0e3bcd941b41c0c3dabebdb545f8331ddbb25257e6bc2cd3b6e6233d64f5","ParentId":"d242d0f728d9aaec3a24215bd3f6fc85a365f36bbb97727a84d5de7cc45792c4","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":23990121,"VirtualSize":411598524}
+        ,{"Created":1415863518,"Id":"d242d0f728d9aaec3a24215bd3f6fc85a365f36bbb97727a84d5de7cc45792c4","ParentId":"b3b586534b2a68b97cec6e3d676fe1b2a1713565929c7e9ff331aad04eaf83cb","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":11550557,"VirtualSize":387608403}
+        ,{"Created":1415863510,"Id":"b3b586534b2a68b97cec6e3d676fe1b2a1713565929c7e9ff331aad04eaf83cb","ParentId":"1ac06968b34e2b5b7c4e16488a4059f6493018f6744a57cf6a4fd2418f7acc4f","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":73,"VirtualSize":376057846}
+        ,{"Created":1415863509,"Id":"1ac06968b34e2b5b7c4e16488a4059f6493018f6744a57cf6a4fd2418f7acc4f","ParentId":"7d49ba12f2de52ae8dfec8c661f4471e00d546b57adc3913cefc56f89b932e22","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1879606,"VirtualSize":376057773}
+        ,{"Created":1415309161,"Id":"7d49ba12f2de52ae8dfec8c661f4471e00d546b57adc3913cefc56f89b932e22","ParentId":"5506de2b643be1e6febbf3b8a240760c6843244c41e12aa2f60ccbb7153d17f5","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":174920601,"VirtualSize":374178167}
+        ,{"Created":1415306638,"Id":"f6fab3b798be3174f45aa1eb731f8182705555f89c9026d8c1ef230cbf8301dd","ParentId":"f10807909bc552de261ca7463effc467600c3dca68d8e7704425283a6911d2ca","RepoTags":["debian:wheezy"],"Size":0,"VirtualSize":85100505}
+        ,{"Created":1415306636,"Id":"f10807909bc552de261ca7463effc467600c3dca68d8e7704425283a6911d2ca","ParentId":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":85100505,"VirtualSize":85100505}
+        ,{"Created":1414177799,"Id":"c723c9b95ac05c29c3e96b0b02e8fcf12096d850306b776a17877ee061daf49f","ParentId":"74dc9d28a649ac161e2a70d84190fe576f77f403f2565012f07bd68d638d291a","RepoTags":["registry:0.7.3"],"Size":0,"VirtualSize":426413472}
+        ,{"Created":1414177799,"Id":"74dc9d28a649ac161e2a70d84190fe576f77f403f2565012f07bd68d638d291a","ParentId":"00bcc0fe318f87107ed0db582ed109899506cd2cde230505ea11a5c400e9ac7a","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":426413472}
+        ,{"Created":1414177798,"Id":"00bcc0fe318f87107ed0db582ed109899506cd2cde230505ea11a5c400e9ac7a","ParentId":"96490e2b34642fabcdf6c4c157bd07be2caf4a71b9bd42c27386a1ff28d94d0c","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":426413472}
+        ,{"Created":1414177798,"Id":"96490e2b34642fabcdf6c4c157bd07be2caf4a71b9bd42c27386a1ff28d94d0c","ParentId":"1168ef7bd438745360d3506a6182ed73fec60bfea4181732dd75d6447016f012","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":426413472}
+        ,{"Created":1414177797,"Id":"1168ef7bd438745360d3506a6182ed73fec60bfea4181732dd75d6447016f012","ParentId":"a9c8dae074b96475a0775e199f79e456f0ee9a8288164e0b84fcc65ca163432e","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":20135062,"VirtualSize":426413472}
+        ,{"Created":1414177667,"Id":"a9c8dae074b96475a0775e199f79e456f0ee9a8288164e0b84fcc65ca163432e","ParentId":"17b869d7773564fa1ca26ef3aa5b3a9e615dabd1a433a4a00848c0c9790096fe","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":8437018,"VirtualSize":406278410}
+        ,{"Created":1414177663,"Id":"17b869d7773564fa1ca26ef3aa5b3a9e615dabd1a433a4a00848c0c9790096fe","ParentId":"4627c1e0f2389a25dce44361dba566542607509b4fec86cc7fae9f6bb93dc2eb","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":73,"VirtualSize":397841392}
+        ,{"Created":1414177663,"Id":"4627c1e0f2389a25dce44361dba566542607509b4fec86cc7fae9f6bb93dc2eb","ParentId":"6ffb25246d5531cdbf15ac250dcf0d10fca544944eaf7386b4cff8577488f258","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1657815,"VirtualSize":397841319}
+        ,{"Created":1414174623,"Id":"881f05ab63649f7d4b4ab048a2e01725c6a2d45f8866807bdb7766e28cdf224e","ParentId":"74583b71c35c28e06e11e0af0193351b852f3e9466a7b2c19a3add9a8528ee57","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":462038905}
+        ,{"Created":1414174623,"Id":"bee70978874ce288a546770e762196041c90d5b0c0ef7e0c3d2e551d79417701","ParentId":"881f05ab63649f7d4b4ab048a2e01725c6a2d45f8866807bdb7766e28cdf224e","RepoTags":["registry:0.6.9"],"Size":0,"VirtualSize":462038905}
+        ,{"Created":1414174623,"Id":"74583b71c35c28e06e11e0af0193351b852f3e9466a7b2c19a3add9a8528ee57","ParentId":"0909821a1551e63f5b169edaa3fa460134d86aa0ed5e6ed3acb4f50afa98002d","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":462038905}
+        ,{"Created":1414174622,"Id":"0909821a1551e63f5b169edaa3fa460134d86aa0ed5e6ed3acb4f50afa98002d","ParentId":"ad702f54c76e4d5e1fb47f9efc355c871f7087ae772ca0fafeedad8185d17058","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":34915187,"VirtualSize":462038905}
+        ,{"Created":1414174578,"Id":"29b16b1bfd162dd7b35cb98a72ad44108361bede4e42679e01dd8aa15aa1fe0f","ParentId":"f6d75c7fe58a905c14381100921562877d06a759acc70fbda6d3863796e0f003","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1613702,"VirtualSize":427123645}
+        ,{"Created":1414174578,"Id":"ad702f54c76e4d5e1fb47f9efc355c871f7087ae772ca0fafeedad8185d17058","ParentId":"29b16b1bfd162dd7b35cb98a72ad44108361bede4e42679e01dd8aa15aa1fe0f","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":73,"VirtualSize":427123718}
+        ,{"Created":1414126280,"Id":"6ffb25246d5531cdbf15ac250dcf0d10fca544944eaf7386b4cff8577488f258","ParentId":"9fe54074b35a3dd77eb2ffe2edf9226645e71fe292964b6d662a4010e695d9b8","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":41247201,"VirtualSize":396183504}
+        ,{"Created":1414126257,"Id":"9fe54074b35a3dd77eb2ffe2edf9226645e71fe292964b6d662a4010e695d9b8","ParentId":"cd72e4fcfd16a48d617cc8fe6c692400b55c3dd013a357f485a08a820f1f75ab","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":135294909,"VirtualSize":354936303}
+        ,{"Created":1414126216,"Id":"cd72e4fcfd16a48d617cc8fe6c692400b55c3dd013a357f485a08a820f1f75ab","ParentId":"57b5d5cb0bfe239f714f9a00439d7774f3b3359270f81ea74b41dbd7775eb46a","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":219641394}
+        ,{"Created":1414126211,"Id":"57b5d5cb0bfe239f714f9a00439d7774f3b3359270f81ea74b41dbd7775eb46a","ParentId":"5506de2b643be1e6febbf3b8a240760c6843244c41e12aa2f60ccbb7153d17f5","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":20383828,"VirtualSize":219641394}
+        ,{"Created":1414108439,"Id":"5506de2b643be1e6febbf3b8a240760c6843244c41e12aa2f60ccbb7153d17f5","ParentId":"22093c35d77bb609b9257ffb2640845ec05018e3d96cb939f68d0e19127f1723","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":199257566}
+        ,{"Created":1414108438,"Id":"22093c35d77bb609b9257ffb2640845ec05018e3d96cb939f68d0e19127f1723","ParentId":"3680052c0f5cf8ecb86ddf4d6ed331c89cdb691554572a80ec04724cf6ee9436","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":6557772,"VirtualSize":199257566}
+        ,{"Created":1414108414,"Id":"3680052c0f5cf8ecb86ddf4d6ed331c89cdb691554572a80ec04724cf6ee9436","ParentId":"e791be0477f28fd52f7609aed81733427d4cc0da620962d072e18ebcb32720a4","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1895,"VirtualSize":192699794}
+        ,{"Created":1414108413,"Id":"e791be0477f28fd52f7609aed81733427d4cc0da620962d072e18ebcb32720a4","ParentId":"ccb62158e97068cc05b2f0927a8acde14c64d0d363cc448238357fe221a39699","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":192697899}
+        ,{"Created":1414108412,"Id":"ccb62158e97068cc05b2f0927a8acde14c64d0d363cc448238357fe221a39699","ParentId":"d497ad3926c8997e1e0de74cdd5285489bb2c4acd6db15292e04bbab07047cd0","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":194791,"VirtualSize":192697899}
+        ,{"Created":1413872056,"Id":"d497ad3926c8997e1e0de74cdd5285489bb2c4acd6db15292e04bbab07047cd0","ParentId":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":192503108,"VirtualSize":192503108}
+        ,{"Created":1412204406,"Id":"f6d75c7fe58a905c14381100921562877d06a759acc70fbda6d3863796e0f003","ParentId":"b083996910428bc46e25ad7c7c0d5dd84c8ced88fe0cceeafe01787d9abd8848","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":6614587,"VirtualSize":425509943}
+        ,{"Created":1412204399,"Id":"b083996910428bc46e25ad7c7c0d5dd84c8ced88fe0cceeafe01787d9abd8848","ParentId":"c07f578f0911d8a712ae9e6909f8778fae749d0dabf65542aba8428c553388ac","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":10478,"VirtualSize":418895356}
+        ,{"Created":1412204376,"Id":"c07f578f0911d8a712ae9e6909f8778fae749d0dabf65542aba8428c553388ac","ParentId":"195eb90b534950d334188c3627f860fbdf898e224d8a0a11ec54ff453175e081","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":234168708,"VirtualSize":418884878}
+        ,{"Created":1412196370,"Id":"d415c60e5ea32875e4ddc7f7578bfaac3d59fb16e1334e705398b10ee91af801","ParentId":"0dfaa2625e19b0925a9e0fc7ea2c2a7f4fd0d31ec1e9838d08bf1310965ffc75","RepoTags":["busybox:ubuntu-12.04"],"Size":0,"VirtualSize":5454693}
+        ,{"Created":1412196370,"Id":"0dfaa2625e19b0925a9e0fc7ea2c2a7f4fd0d31ec1e9838d08bf1310965ffc75","ParentId":"df7546f9f060a2268024c8a230d8639878585defcc1bc6f79d2728a13957871b","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":5454693,"VirtualSize":5454693}
+        ,{"Created":1412196368,"Id":"e72ac664f4f0c6a061ac4ef332557a70d69b0c624b6add35f1c181ff7fff2287","ParentId":"e433a6c5b276a31aa38bf6eaba9cd1cfd69ea33f706ed72b3f20bafde5cd8644","RepoTags":["busybox:buildroot-2014.02","busybox:latest"],"Size":0,"VirtualSize":2433303}
+        ,{"Created":1412196368,"Id":"e433a6c5b276a31aa38bf6eaba9cd1cfd69ea33f706ed72b3f20bafde5cd8644","ParentId":"df7546f9f060a2268024c8a230d8639878585defcc1bc6f79d2728a13957871b","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":2433303,"VirtualSize":2433303}
+        ,{"Created":1412196367,"Id":"4b2909447dbef01f71ca476725c2dbb3af12de41aa2d7491d62c66678ede2294","ParentId":"ad8766e8635d2ae9ddd77d32b8f0fa091fb88fffed77b3a8a240bdcdc6f5aa05","RepoTags":["busybox:buildroot-2013.08.1"],"Size":0,"VirtualSize":2489301}
+        ,{"Created":1412196367,"Id":"df7546f9f060a2268024c8a230d8639878585defcc1bc6f79d2728a13957871b","ParentId":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":0}
+        ,{"Created":1412196367,"Id":"ad8766e8635d2ae9ddd77d32b8f0fa091fb88fffed77b3a8a240bdcdc6f5aa05","ParentId":"df7546f9f060a2268024c8a230d8639878585defcc1bc6f79d2728a13957871b","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":2489301,"VirtualSize":2489301}
+        ,{"Created":1403128415,"Id":"195eb90b534950d334188c3627f860fbdf898e224d8a0a11ec54ff453175e081","ParentId":"209ea56fda6dc2fb013e4d1e40cb678b2af91d1b54a71529f7df0bd867adc961","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":4411741,"VirtualSize":184716170}
+        ,{"Created":1403128408,"Id":"209ea56fda6dc2fb013e4d1e40cb678b2af91d1b54a71529f7df0bd867adc961","ParentId":"0f4aac48388f5d65a725ccf8e7caada42f136026c566528a5ee9b02467dac90a","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":74007417,"VirtualSize":180304429}
+        ,{"Created":1403128396,"Id":"0f4aac48388f5d65a725ccf8e7caada42f136026c566528a5ee9b02467dac90a","ParentId":"fae16849ebe23b48f2bedcc08aaabd45408c62b531ffd8d3088592043d5e7364","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1887,"VirtualSize":106297012}
+        ,{"Created":1403128396,"Id":"fae16849ebe23b48f2bedcc08aaabd45408c62b531ffd8d3088592043d5e7364","ParentId":"f127542f0b6191e99bb015b672f5cf48fa79d974784ac8090b11aeac184eaaff","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":189999,"VirtualSize":106295125}
+        ,{"Created":1403128393,"Id":"f127542f0b6191e99bb015b672f5cf48fa79d974784ac8090b11aeac184eaaff","ParentId":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":106105126,"VirtualSize":106105126}
+        ,{"Created":1371157430,"Id":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","ParentId":"","RepoTags":["scratch:latest"],"Size":0,"VirtualSize":0}
+        ]
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:44 GMT
+- request:
+    method: get
+    uri: "<DOCKER_HOST>/v1.15/images/b239f80471db/json"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Dec 2014 18:08:44 GMT
+      Content-Length:
+      - '1451'
+    body:
+      encoding: UTF-8
+      string: |
+        {"Architecture":"amd64","Author":"","Comment":"","Config":{"AttachStderr":false,"AttachStdin":false,"AttachStdout":false,"Cmd":["/true"],"CpuShares":0,"Cpuset":"","Domainname":"","Entrypoint":null,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","TRIVIAL=CHANGE"],"ExposedPorts":null,"Hostname":"0d1fedb580de","Image":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","Memory":0,"MemorySwap":0,"NetworkDisabled":false,"OnBuild":[],"OpenStdin":false,"PortSpecs":null,"SecurityOpt":null,"StdinOnce":false,"Tty":false,"User":"","Volumes":null,"WorkingDir":""},"Container":"6d0c01400c38e0783f2be9f22d9ef47c1e8b56fa83085d4d7ea360e94916640f","ContainerConfig":{"AttachStderr":false,"AttachStdin":false,"AttachStdout":false,"Cmd":["/bin/sh","-c","#(nop) ENV TRIVIAL=CHANGE"],"CpuShares":0,"Cpuset":"","Domainname":"","Entrypoint":null,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","TRIVIAL=CHANGE"],"ExposedPorts":null,"Hostname":"0d1fedb580de","Image":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","Memory":0,"MemorySwap":0,"NetworkDisabled":false,"OnBuild":[],"OpenStdin":false,"PortSpecs":null,"SecurityOpt":null,"StdinOnce":false,"Tty":false,"User":"","Volumes":null,"WorkingDir":""},"Created":"2014-12-10T02:32:41.527606628Z","DockerVersion":"1.3.1","Id":"b239f80471dbc0ee17ca34e648e4cc0b1013c740bccb621d6ad00edbc3f26dc7","Os":"linux","Parent":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","Size":0,"VirtualSize":125}
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:44 GMT
+- request:
+    method: post
+    uri: "<DOCKER_HOST>/v1.15/images/<USERNAME>/true/push?tag=latest"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - text/plain
+      X-Registry-Auth:
+      - eyJ1c2VybmFtZSI6InRkdWZmaWVsZCIsInBhc3N3b3JkIjoiaTlCZj5KZ3ZmYmpZL3NKV01jVTkiLCJzZXJ2ZXJhZGRyZXNzIjoiaHR0cHM6Ly9pbmRleC5kb2NrZXIuaW8vdjEiLCJlbWFpbCI6ImdpdGh1YkB0b21kdWZmaWVsZC5jb20ifQ==
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Dec 2014 18:08:44 GMT
+    body:
+      encoding: UTF-8
+      string: "{\"status\":\"The push refers to a repository [<USERNAME>/true] (len:
+        1)\"}\r\n{\"status\":\"Sending image list\"}\r\n{\"status\":\"Pushing repository
+        <USERNAME>/true (1 tags)\"}\r\n{\"status\":\"Pushing\",\"progressDetail\":{},\"id\":\"511136ea3c5a\"}{\"status\":\"Image
+        already pushed, skipping\",\"progressDetail\":{},\"id\":\"511136ea3c5a\"}{\"status\":\"Pushing\",\"progressDetail\":{},\"id\":\"9d182a4ffb01\"}{\"status\":\"Image
+        already pushed, skipping\",\"progressDetail\":{},\"id\":\"9d182a4ffb01\"}{\"status\":\"Pushing\",\"progressDetail\":{},\"id\":\"69e7aca3d78e\"}{\"status\":\"Image
+        already pushed, skipping\",\"progressDetail\":{},\"id\":\"69e7aca3d78e\"}{\"status\":\"Pushing\",\"progressDetail\":{},\"id\":\"b239f80471db\"}{\"status\":\"Buffering
+        to disk\",\"progressDetail\":{\"current\":3072,\"start\":1418178781},\"progress\":\"3.072
+        kB\",\"id\":\"b239f80471db\"}{\"status\":\"Buffering to disk\",\"progressDetail\":{\"start\":1418178781},\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":512,\"total\":3072,\"start\":1418178781},\"progress\":\"[========\\u003e
+        \                                         ]    512 B/3.072 kB 3s\",\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":1024,\"total\":3072,\"start\":1418178781},\"progress\":\"[================\\u003e
+        \                                 ] 1.024 kB/3.072 kB 1s\",\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":1536,\"total\":3072,\"start\":1418178781},\"progress\":\"[=========================\\u003e
+        \                        ] 1.536 kB/3.072 kB 0\",\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":2048,\"total\":3072,\"start\":1418178781},\"progress\":\"[=================================\\u003e
+        \                ] 2.048 kB/3.072 kB 0\",\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":2560,\"total\":3072,\"start\":1418178781},\"progress\":\"[=========================================\\u003e
+        \        ]  2.56 kB/3.072 kB 0\",\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":3072,\"total\":3072,\"start\":1418178781},\"progress\":\"[==================================================\\u003e]
+        3.072 kB/3.072 kB\",\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":3072,\"total\":3072,\"start\":1418178781},\"progress\":\"[==================================================\\u003e]
+        3.072 kB/3.072 kB\",\"id\":\"b239f80471db\"}{\"status\":\"Image successfully
+        pushed\",\"progressDetail\":{},\"id\":\"b239f80471db\"}{\"status\":\"Pushing
+        tag for rev [b239f80471db] on {https://cdn-registry-1.docker.io/v1/repositories/<USERNAME>/true/tags/latest}\"}\r\n"
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:45 GMT
+- request:
+    method: delete
+    uri: "<DOCKER_HOST>/v1.15/images/<USERNAME>/true?noprune=true"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Dec 2014 18:08:45 GMT
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: |-
+        [{"Untagged":"<USERNAME>/true:latest"}
+        ]
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:45 GMT
+recorded_with: VCR 2.9.3

--- a/spec/vcr/Docker_Image/_push/pushes_the_Image.yml
+++ b/spec/vcr/Docker_Image/_push/pushes_the_Image.yml
@@ -69,7 +69,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "{\"stream\":\"Step 0 : FROM tianon/true\\n\"}\r\n{\"stream\":\" ---\\u003e
-        08e20b347507\\n\"}\r\n{\"stream\":\"Successfully built 08e20b347507\\n\"}\r\n"
+        69e7aca3d78e\\n\"}\r\n{\"stream\":\"Step 1 : ENV TRIVIAL CHANGE\\n\"}\r\n{\"stream\":\"
+        ---\\u003e Running in 6d0c01400c38\\n\"}\r\n{\"stream\":\" ---\\u003e b239f80471db\\n\"}\r\n{\"stream\":\"Removing
+        intermediate container 6d0c01400c38\\n\"}\r\n{\"stream\":\"Successfully built
+        b239f80471db\\n\"}\r\n"
     http_version: 
   recorded_at: Mon, 01 Dec 2014 18:08:44 GMT
 - request:
@@ -95,7 +98,8 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |-
-        [{"Created":1416799251,"Id":"08e20b3475072326a5f6855b4bca4fe53680d025f379eb54c5076de119cae17b","ParentId":"0b7a3c1fbea815d721ccf5404d05e0d8c667945ebe21acdf530fae3aa22184ce","RepoTags":["tianon/true:latest","<USERNAME>/true:latest"],"Size":0,"VirtualSize":125}
+        [{"Created":1418178761,"Id":"b239f80471dbc0ee17ca34e648e4cc0b1013c740bccb621d6ad00edbc3f26dc7","ParentId":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","RepoTags":["<USERNAME>/true:latest"],"Size":0,"VirtualSize":125}
+        ,{"Created":1417805428,"Id":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","ParentId":"9d182a4ffb01e4ecfc5397bf9a989016e7ae6920f6e64a037db4c0a2f3c0e264","RepoTags":["tianon/true:latest"],"Size":0,"VirtualSize":125}
         ,{"Created":1416799251,"Id":"0b7a3c1fbea815d721ccf5404d05e0d8c667945ebe21acdf530fae3aa22184ce","ParentId":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":125,"VirtualSize":125}
         ,{"Created":1415864019,"Id":"74f5b38a45c97043cdf0082b8e8dd002497ab6b03388cdb2f20bafb7468ad55b","ParentId":"31ae66be94f160a92e1e757ab9a66aa7183af55183080576fb93a52cbce9e0cd","RepoTags":["registry:0.9.0"],"Size":0,"VirtualSize":411649756}
         ,{"Created":1415864018,"Id":"31ae66be94f160a92e1e757ab9a66aa7183af55183080576fb93a52cbce9e0cd","ParentId":"b3fd13d94685095ec1c1f8f0f371dde8be9a21f8f457d4d10e5ad72042a152af","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649756}
@@ -171,7 +175,7 @@ http_interactions:
   recorded_at: Mon, 01 Dec 2014 18:08:44 GMT
 - request:
     method: get
-    uri: "<DOCKER_HOST>/v1.15/images/08e20b347507/json"
+    uri: "<DOCKER_HOST>/v1.15/images/b239f80471db/json"
     body:
       encoding: US-ASCII
       string: ''
@@ -194,12 +198,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {"Architecture":"amd64","Author":"","Comment":"","Config":{"AttachStderr":false,"AttachStdin":false,"AttachStdout":false,"Cmd":["/true"],"CpuShares":0,"Cpuset":"","Domainname":"","Entrypoint":null,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],"ExposedPorts":null,"Hostname":"cb7d701676d5","Image":"0b7a3c1fbea815d721ccf5404d05e0d8c667945ebe21acdf530fae3aa22184ce","Memory":0,"MemorySwap":0,"NetworkDisabled":false,"OnBuild":[],"OpenStdin":false,"PortSpecs":null,"StdinOnce":false,"Tty":false,"User":"","Volumes":null,"WorkingDir":""},"Container":"c21f74268c73d08aee59691b5b4b5771ca49cdc73dee76a3778cc214801da20e","ContainerConfig":{"AttachStderr":false,"AttachStdin":false,"AttachStdout":false,"Cmd":["/bin/sh","-c","#(nop) CMD [/true]"],"CpuShares":0,"Cpuset":"","Domainname":"","Entrypoint":null,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],"ExposedPorts":null,"Hostname":"cb7d701676d5","Image":"0b7a3c1fbea815d721ccf5404d05e0d8c667945ebe21acdf530fae3aa22184ce","Memory":0,"MemorySwap":0,"NetworkDisabled":false,"OnBuild":[],"OpenStdin":false,"PortSpecs":null,"StdinOnce":false,"Tty":false,"User":"","Volumes":null,"WorkingDir":""},"Created":"2014-11-24T03:20:51.740435043Z","DockerVersion":"1.3.2","Id":"08e20b3475072326a5f6855b4bca4fe53680d025f379eb54c5076de119cae17b","Os":"linux","Parent":"0b7a3c1fbea815d721ccf5404d05e0d8c667945ebe21acdf530fae3aa22184ce","Size":0,"VirtualSize":125}
+        {"Architecture":"amd64","Author":"","Comment":"","Config":{"AttachStderr":false,"AttachStdin":false,"AttachStdout":false,"Cmd":["/true"],"CpuShares":0,"Cpuset":"","Domainname":"","Entrypoint":null,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","TRIVIAL=CHANGE"],"ExposedPorts":null,"Hostname":"0d1fedb580de","Image":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","Memory":0,"MemorySwap":0,"NetworkDisabled":false,"OnBuild":[],"OpenStdin":false,"PortSpecs":null,"SecurityOpt":null,"StdinOnce":false,"Tty":false,"User":"","Volumes":null,"WorkingDir":""},"Container":"6d0c01400c38e0783f2be9f22d9ef47c1e8b56fa83085d4d7ea360e94916640f","ContainerConfig":{"AttachStderr":false,"AttachStdin":false,"AttachStdout":false,"Cmd":["/bin/sh","-c","#(nop) ENV TRIVIAL=CHANGE"],"CpuShares":0,"Cpuset":"","Domainname":"","Entrypoint":null,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","TRIVIAL=CHANGE"],"ExposedPorts":null,"Hostname":"0d1fedb580de","Image":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","Memory":0,"MemorySwap":0,"NetworkDisabled":false,"OnBuild":[],"OpenStdin":false,"PortSpecs":null,"SecurityOpt":null,"StdinOnce":false,"Tty":false,"User":"","Volumes":null,"WorkingDir":""},"Created":"2014-12-10T02:32:41.527606628Z","DockerVersion":"1.3.1","Id":"b239f80471dbc0ee17ca34e648e4cc0b1013c740bccb621d6ad00edbc3f26dc7","Os":"linux","Parent":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","Size":0,"VirtualSize":125}
     http_version: 
   recorded_at: Mon, 01 Dec 2014 18:08:44 GMT
 - request:
     method: post
-    uri: "<DOCKER_HOST>/v1.15/images/tianon/true/push?tag=latest"
+    uri: "<DOCKER_HOST>/v1.15/images/<USERNAME>/true/push?tag=latest"
     body:
       encoding: US-ASCII
       string: ''
@@ -221,11 +225,23 @@ http_interactions:
       - Mon, 01 Dec 2014 18:08:44 GMT
     body:
       encoding: UTF-8
-      string: "{\"status\":\"The push refers to a repository [tianon/true] (len: 1)\"}\r\n{\"status\":\"Sending
-        image list\"}\r\n{\"errorDetail\":{\"message\":\"Error: Status 403 trying
-        to push repository tianon/true: \\\"Access denied, you don't have access to
-        this repo\\\"\"},\"error\":\"Error: Status 403 trying to push repository tianon/true:
-        \\\"Access denied, you don't have access to this repo\\\"\"}\r\n"
+      string: "{\"status\":\"The push refers to a repository [<USERNAME>/true] (len:
+        1)\"}\r\n{\"status\":\"Sending image list\"}\r\n{\"status\":\"Pushing repository
+        <USERNAME>/true (1 tags)\"}\r\n{\"status\":\"Pushing\",\"progressDetail\":{},\"id\":\"511136ea3c5a\"}{\"status\":\"Image
+        already pushed, skipping\",\"progressDetail\":{},\"id\":\"511136ea3c5a\"}{\"status\":\"Pushing\",\"progressDetail\":{},\"id\":\"9d182a4ffb01\"}{\"status\":\"Image
+        already pushed, skipping\",\"progressDetail\":{},\"id\":\"9d182a4ffb01\"}{\"status\":\"Pushing\",\"progressDetail\":{},\"id\":\"69e7aca3d78e\"}{\"status\":\"Image
+        already pushed, skipping\",\"progressDetail\":{},\"id\":\"69e7aca3d78e\"}{\"status\":\"Pushing\",\"progressDetail\":{},\"id\":\"b239f80471db\"}{\"status\":\"Buffering
+        to disk\",\"progressDetail\":{\"current\":3072,\"start\":1418178781},\"progress\":\"3.072
+        kB\",\"id\":\"b239f80471db\"}{\"status\":\"Buffering to disk\",\"progressDetail\":{\"start\":1418178781},\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":512,\"total\":3072,\"start\":1418178781},\"progress\":\"[========\\u003e
+        \                                         ]    512 B/3.072 kB 3s\",\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":1024,\"total\":3072,\"start\":1418178781},\"progress\":\"[================\\u003e
+        \                                 ] 1.024 kB/3.072 kB 1s\",\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":1536,\"total\":3072,\"start\":1418178781},\"progress\":\"[=========================\\u003e
+        \                        ] 1.536 kB/3.072 kB 0\",\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":2048,\"total\":3072,\"start\":1418178781},\"progress\":\"[=================================\\u003e
+        \                ] 2.048 kB/3.072 kB 0\",\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":2560,\"total\":3072,\"start\":1418178781},\"progress\":\"[=========================================\\u003e
+        \        ]  2.56 kB/3.072 kB 0\",\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":3072,\"total\":3072,\"start\":1418178781},\"progress\":\"[==================================================\\u003e]
+        3.072 kB/3.072 kB\",\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":3072,\"total\":3072,\"start\":1418178781},\"progress\":\"[==================================================\\u003e]
+        3.072 kB/3.072 kB\",\"id\":\"b239f80471db\"}{\"status\":\"Image successfully
+        pushed\",\"progressDetail\":{},\"id\":\"b239f80471db\"}{\"status\":\"Pushing
+        tag for rev [b239f80471db] on {https://cdn-registry-1.docker.io/v1/repositories/<USERNAME>/true/tags/latest}\"}\r\n"
     http_version: 
   recorded_at: Mon, 01 Dec 2014 18:08:45 GMT
 - request:

--- a/spec/vcr/Docker_Image/_push/raises_an_error_if_alien_name_supplied.yml
+++ b/spec/vcr/Docker_Image/_push/raises_an_error_if_alien_name_supplied.yml
@@ -1,0 +1,233 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<DOCKER_HOST>/v1.15/build?t=<USERNAME>%2Ftrue"
+    body:
+      encoding: UTF-8
+      string: !binary |-
+        RG9ja2VyZmlsZQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAADAwMDA2NDAAMDAwMDAwMAAwMDAwMDAwADAwMDAwMDAwMDIx
+        ADEyNDM3MTI3MjU0ADAxMzMwNAAgMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB1c3RhcgAwMHdoZWVs
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAd2hlZWwAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAwMDAwMDAwADAwMDAwMDAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAABGUk9NIHRpYW5vbi90cnVlCgAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Dec 2014 18:08:44 GMT
+    body:
+      encoding: UTF-8
+      string: "{\"stream\":\"Step 0 : FROM tianon/true\\n\"}\r\n{\"stream\":\" ---\\u003e
+        69e7aca3d78e\\n\"}\r\n{\"stream\":\"Step 1 : ENV TRIVIAL CHANGE\\n\"}\r\n{\"stream\":\"
+        ---\\u003e Running in 6d0c01400c38\\n\"}\r\n{\"stream\":\" ---\\u003e b239f80471db\\n\"}\r\n{\"stream\":\"Removing
+        intermediate container 6d0c01400c38\\n\"}\r\n{\"stream\":\"Successfully built
+        b239f80471db\\n\"}\r\n"
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:44 GMT
+- request:
+    method: get
+    uri: "<DOCKER_HOST>/v1.15/images/json?all=true"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Dec 2014 18:08:44 GMT
+    body:
+      encoding: UTF-8
+      string: |-
+        [{"Created":1418178761,"Id":"b239f80471dbc0ee17ca34e648e4cc0b1013c740bccb621d6ad00edbc3f26dc7","ParentId":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","RepoTags":["<USERNAME>/true:latest"],"Size":0,"VirtualSize":125}
+        ,{"Created":1417805428,"Id":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","ParentId":"9d182a4ffb01e4ecfc5397bf9a989016e7ae6920f6e64a037db4c0a2f3c0e264","RepoTags":["tianon/true:latest"],"Size":0,"VirtualSize":125}
+        ,{"Created":1416799251,"Id":"0b7a3c1fbea815d721ccf5404d05e0d8c667945ebe21acdf530fae3aa22184ce","ParentId":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":125,"VirtualSize":125}
+        ,{"Created":1415864019,"Id":"74f5b38a45c97043cdf0082b8e8dd002497ab6b03388cdb2f20bafb7468ad55b","ParentId":"31ae66be94f160a92e1e757ab9a66aa7183af55183080576fb93a52cbce9e0cd","RepoTags":["registry:0.9.0"],"Size":0,"VirtualSize":411649756}
+        ,{"Created":1415864018,"Id":"31ae66be94f160a92e1e757ab9a66aa7183af55183080576fb93a52cbce9e0cd","ParentId":"b3fd13d94685095ec1c1f8f0f371dde8be9a21f8f457d4d10e5ad72042a152af","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649756}
+        ,{"Created":1415864017,"Id":"eae8be82bb623181222558e4df0dd59c943cdc2fd3c4e41de669e4bd35a866e6","ParentId":"8eae38b276496440046cd9f545c24533e692cbed6fd1bc4e29a7af5e4ae72a61","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649756}
+        ,{"Created":1415864017,"Id":"b3fd13d94685095ec1c1f8f0f371dde8be9a21f8f457d4d10e5ad72042a152af","ParentId":"eae8be82bb623181222558e4df0dd59c943cdc2fd3c4e41de669e4bd35a866e6","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649756}
+        ,{"Created":1415864016,"Id":"8eae38b276496440046cd9f545c24533e692cbed6fd1bc4e29a7af5e4ae72a61","ParentId":"16b02bf8dc3d1f70e098cbd968f154468fcf41be6bf59b24a35b4fdded3edbca","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":50796,"VirtualSize":411649756}
+        ,{"Created":1415864015,"Id":"16b02bf8dc3d1f70e098cbd968f154468fcf41be6bf59b24a35b4fdded3edbca","ParentId":"b22cb7ed5ccbeeaf2a67d5d3034a308c6eedf2ccb247851c9a14c05b441716fa","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":23990121,"VirtualSize":411598960}
+        ,{"Created":1415863862,"Id":"b22cb7ed5ccbeeaf2a67d5d3034a308c6eedf2ccb247851c9a14c05b441716fa","ParentId":"8b170afd480f41a84331dcaabfa6465769205e645ba13f8baa085f1f68e4f1cf","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":11550557,"VirtualSize":387608839}
+        ,{"Created":1415863855,"Id":"8b170afd480f41a84331dcaabfa6465769205e645ba13f8baa085f1f68e4f1cf","ParentId":"8dda8bb23254979ce24f2ca4d7115f4563a9ae4f0e774b2d419318d81a5c720d","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":73,"VirtualSize":376058282}
+        ,{"Created":1415863853,"Id":"8dda8bb23254979ce24f2ca4d7115f4563a9ae4f0e774b2d419318d81a5c720d","ParentId":"7d49ba12f2de52ae8dfec8c661f4471e00d546b57adc3913cefc56f89b932e22","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1880042,"VirtualSize":376058209}
+        ,{"Created":1415863849,"Id":"d9925ba888d4dba2d9b22273d261155fe3b2a4e6cfa5db44e4abe5ac8e311efa","ParentId":"4abfff610473315c2fb7a6278c924948ba877fe6630ad197f734572b7636188e","RepoTags":["registry:0.8.1"],"Size":0,"VirtualSize":430388853}
+        ,{"Created":1415863848,"Id":"4abfff610473315c2fb7a6278c924948ba877fe6630ad197f734572b7636188e","ParentId":"8b840022b4b5d60e0f66d7f72b992eb5b52e75dfdf1b8e9535d85df57236e7f5","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":430388853}
+        ,{"Created":1415863847,"Id":"8b840022b4b5d60e0f66d7f72b992eb5b52e75dfdf1b8e9535d85df57236e7f5","ParentId":"11d3a913c69b0ea1c7d0df3708dfa8c789b68dc0884471cf862de1160c7eaaba","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":430388853}
+        ,{"Created":1415863846,"Id":"11d3a913c69b0ea1c7d0df3708dfa8c789b68dc0884471cf862de1160c7eaaba","ParentId":"ae88728b911af97e928890b1c3b7b34dd25fb313f3b20cd73e532e2903d3d3b9","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":430388853}
+        ,{"Created":1415863845,"Id":"ae88728b911af97e928890b1c3b7b34dd25fb313f3b20cd73e532e2903d3d3b9","ParentId":"16c101215b54ac2210fa62d54e0893323ae43e3d33b75119b1246a9dbbc1c7cf","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":23901352,"VirtualSize":430388853}
+        ,{"Created":1415863690,"Id":"16c101215b54ac2210fa62d54e0893323ae43e3d33b75119b1246a9dbbc1c7cf","ParentId":"4c86ccffaf465d6688815f844bfadbb91a76df42043e629d208c5b75de31b891","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":8442747,"VirtualSize":406487501}
+        ,{"Created":1415863686,"Id":"4c86ccffaf465d6688815f844bfadbb91a76df42043e629d208c5b75de31b891","ParentId":"e930198c27c4d790fd3eece5212c7ab1e6f272bfd21061c877b38696aa91ac27","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":73,"VirtualSize":398044754}
+        ,{"Created":1415863685,"Id":"e930198c27c4d790fd3eece5212c7ab1e6f272bfd21061c877b38696aa91ac27","ParentId":"6ffb25246d5531cdbf15ac250dcf0d10fca544944eaf7386b4cff8577488f258","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1861177,"VirtualSize":398044681}
+        ,{"Created":1415863681,"Id":"7e2db37c6564bf030e6c5af9725bf9f9a8196846e3a77a51e201fc97871e2e60","ParentId":"765d6041baaa23390504094a101b8f4e3433e99a03cb0f5cf20e3b2e3a2a7523","RepoTags":["registry:latest"],"Size":0,"VirtualSize":411649320}
+        ,{"Created":1415863680,"Id":"765d6041baaa23390504094a101b8f4e3433e99a03cb0f5cf20e3b2e3a2a7523","ParentId":"c978e4c4261aec2dbc24c84427460afdaeaa64359ff4ed0ad6d4d00f0e0e0cd7","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649320}
+        ,{"Created":1415863680,"Id":"c978e4c4261aec2dbc24c84427460afdaeaa64359ff4ed0ad6d4d00f0e0e0cd7","ParentId":"f846b2ccf2c5679f8d95014285a8e771441b5e5fc04670e0dfcb1242e985eb5e","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649320}
+        ,{"Created":1415863679,"Id":"7949c9f83980aab0ac80e3150c0d3f899556c68f35d8f6f9ca7c79ecb769b70e","ParentId":"e8ca0e3bcd941b41c0c3dabebdb545f8331ddbb25257e6bc2cd3b6e6233d64f5","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":50796,"VirtualSize":411649320}
+        ,{"Created":1415863679,"Id":"f846b2ccf2c5679f8d95014285a8e771441b5e5fc04670e0dfcb1242e985eb5e","ParentId":"7949c9f83980aab0ac80e3150c0d3f899556c68f35d8f6f9ca7c79ecb769b70e","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649320}
+        ,{"Created":1415863677,"Id":"e8ca0e3bcd941b41c0c3dabebdb545f8331ddbb25257e6bc2cd3b6e6233d64f5","ParentId":"d242d0f728d9aaec3a24215bd3f6fc85a365f36bbb97727a84d5de7cc45792c4","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":23990121,"VirtualSize":411598524}
+        ,{"Created":1415863518,"Id":"d242d0f728d9aaec3a24215bd3f6fc85a365f36bbb97727a84d5de7cc45792c4","ParentId":"b3b586534b2a68b97cec6e3d676fe1b2a1713565929c7e9ff331aad04eaf83cb","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":11550557,"VirtualSize":387608403}
+        ,{"Created":1415863510,"Id":"b3b586534b2a68b97cec6e3d676fe1b2a1713565929c7e9ff331aad04eaf83cb","ParentId":"1ac06968b34e2b5b7c4e16488a4059f6493018f6744a57cf6a4fd2418f7acc4f","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":73,"VirtualSize":376057846}
+        ,{"Created":1415863509,"Id":"1ac06968b34e2b5b7c4e16488a4059f6493018f6744a57cf6a4fd2418f7acc4f","ParentId":"7d49ba12f2de52ae8dfec8c661f4471e00d546b57adc3913cefc56f89b932e22","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1879606,"VirtualSize":376057773}
+        ,{"Created":1415309161,"Id":"7d49ba12f2de52ae8dfec8c661f4471e00d546b57adc3913cefc56f89b932e22","ParentId":"5506de2b643be1e6febbf3b8a240760c6843244c41e12aa2f60ccbb7153d17f5","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":174920601,"VirtualSize":374178167}
+        ,{"Created":1415306638,"Id":"f6fab3b798be3174f45aa1eb731f8182705555f89c9026d8c1ef230cbf8301dd","ParentId":"f10807909bc552de261ca7463effc467600c3dca68d8e7704425283a6911d2ca","RepoTags":["debian:wheezy"],"Size":0,"VirtualSize":85100505}
+        ,{"Created":1415306636,"Id":"f10807909bc552de261ca7463effc467600c3dca68d8e7704425283a6911d2ca","ParentId":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":85100505,"VirtualSize":85100505}
+        ,{"Created":1414177799,"Id":"c723c9b95ac05c29c3e96b0b02e8fcf12096d850306b776a17877ee061daf49f","ParentId":"74dc9d28a649ac161e2a70d84190fe576f77f403f2565012f07bd68d638d291a","RepoTags":["registry:0.7.3"],"Size":0,"VirtualSize":426413472}
+        ,{"Created":1414177799,"Id":"74dc9d28a649ac161e2a70d84190fe576f77f403f2565012f07bd68d638d291a","ParentId":"00bcc0fe318f87107ed0db582ed109899506cd2cde230505ea11a5c400e9ac7a","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":426413472}
+        ,{"Created":1414177798,"Id":"00bcc0fe318f87107ed0db582ed109899506cd2cde230505ea11a5c400e9ac7a","ParentId":"96490e2b34642fabcdf6c4c157bd07be2caf4a71b9bd42c27386a1ff28d94d0c","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":426413472}
+        ,{"Created":1414177798,"Id":"96490e2b34642fabcdf6c4c157bd07be2caf4a71b9bd42c27386a1ff28d94d0c","ParentId":"1168ef7bd438745360d3506a6182ed73fec60bfea4181732dd75d6447016f012","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":426413472}
+        ,{"Created":1414177797,"Id":"1168ef7bd438745360d3506a6182ed73fec60bfea4181732dd75d6447016f012","ParentId":"a9c8dae074b96475a0775e199f79e456f0ee9a8288164e0b84fcc65ca163432e","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":20135062,"VirtualSize":426413472}
+        ,{"Created":1414177667,"Id":"a9c8dae074b96475a0775e199f79e456f0ee9a8288164e0b84fcc65ca163432e","ParentId":"17b869d7773564fa1ca26ef3aa5b3a9e615dabd1a433a4a00848c0c9790096fe","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":8437018,"VirtualSize":406278410}
+        ,{"Created":1414177663,"Id":"17b869d7773564fa1ca26ef3aa5b3a9e615dabd1a433a4a00848c0c9790096fe","ParentId":"4627c1e0f2389a25dce44361dba566542607509b4fec86cc7fae9f6bb93dc2eb","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":73,"VirtualSize":397841392}
+        ,{"Created":1414177663,"Id":"4627c1e0f2389a25dce44361dba566542607509b4fec86cc7fae9f6bb93dc2eb","ParentId":"6ffb25246d5531cdbf15ac250dcf0d10fca544944eaf7386b4cff8577488f258","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1657815,"VirtualSize":397841319}
+        ,{"Created":1414174623,"Id":"881f05ab63649f7d4b4ab048a2e01725c6a2d45f8866807bdb7766e28cdf224e","ParentId":"74583b71c35c28e06e11e0af0193351b852f3e9466a7b2c19a3add9a8528ee57","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":462038905}
+        ,{"Created":1414174623,"Id":"bee70978874ce288a546770e762196041c90d5b0c0ef7e0c3d2e551d79417701","ParentId":"881f05ab63649f7d4b4ab048a2e01725c6a2d45f8866807bdb7766e28cdf224e","RepoTags":["registry:0.6.9"],"Size":0,"VirtualSize":462038905}
+        ,{"Created":1414174623,"Id":"74583b71c35c28e06e11e0af0193351b852f3e9466a7b2c19a3add9a8528ee57","ParentId":"0909821a1551e63f5b169edaa3fa460134d86aa0ed5e6ed3acb4f50afa98002d","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":462038905}
+        ,{"Created":1414174622,"Id":"0909821a1551e63f5b169edaa3fa460134d86aa0ed5e6ed3acb4f50afa98002d","ParentId":"ad702f54c76e4d5e1fb47f9efc355c871f7087ae772ca0fafeedad8185d17058","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":34915187,"VirtualSize":462038905}
+        ,{"Created":1414174578,"Id":"29b16b1bfd162dd7b35cb98a72ad44108361bede4e42679e01dd8aa15aa1fe0f","ParentId":"f6d75c7fe58a905c14381100921562877d06a759acc70fbda6d3863796e0f003","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1613702,"VirtualSize":427123645}
+        ,{"Created":1414174578,"Id":"ad702f54c76e4d5e1fb47f9efc355c871f7087ae772ca0fafeedad8185d17058","ParentId":"29b16b1bfd162dd7b35cb98a72ad44108361bede4e42679e01dd8aa15aa1fe0f","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":73,"VirtualSize":427123718}
+        ,{"Created":1414126280,"Id":"6ffb25246d5531cdbf15ac250dcf0d10fca544944eaf7386b4cff8577488f258","ParentId":"9fe54074b35a3dd77eb2ffe2edf9226645e71fe292964b6d662a4010e695d9b8","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":41247201,"VirtualSize":396183504}
+        ,{"Created":1414126257,"Id":"9fe54074b35a3dd77eb2ffe2edf9226645e71fe292964b6d662a4010e695d9b8","ParentId":"cd72e4fcfd16a48d617cc8fe6c692400b55c3dd013a357f485a08a820f1f75ab","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":135294909,"VirtualSize":354936303}
+        ,{"Created":1414126216,"Id":"cd72e4fcfd16a48d617cc8fe6c692400b55c3dd013a357f485a08a820f1f75ab","ParentId":"57b5d5cb0bfe239f714f9a00439d7774f3b3359270f81ea74b41dbd7775eb46a","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":219641394}
+        ,{"Created":1414126211,"Id":"57b5d5cb0bfe239f714f9a00439d7774f3b3359270f81ea74b41dbd7775eb46a","ParentId":"5506de2b643be1e6febbf3b8a240760c6843244c41e12aa2f60ccbb7153d17f5","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":20383828,"VirtualSize":219641394}
+        ,{"Created":1414108439,"Id":"5506de2b643be1e6febbf3b8a240760c6843244c41e12aa2f60ccbb7153d17f5","ParentId":"22093c35d77bb609b9257ffb2640845ec05018e3d96cb939f68d0e19127f1723","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":199257566}
+        ,{"Created":1414108438,"Id":"22093c35d77bb609b9257ffb2640845ec05018e3d96cb939f68d0e19127f1723","ParentId":"3680052c0f5cf8ecb86ddf4d6ed331c89cdb691554572a80ec04724cf6ee9436","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":6557772,"VirtualSize":199257566}
+        ,{"Created":1414108414,"Id":"3680052c0f5cf8ecb86ddf4d6ed331c89cdb691554572a80ec04724cf6ee9436","ParentId":"e791be0477f28fd52f7609aed81733427d4cc0da620962d072e18ebcb32720a4","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1895,"VirtualSize":192699794}
+        ,{"Created":1414108413,"Id":"e791be0477f28fd52f7609aed81733427d4cc0da620962d072e18ebcb32720a4","ParentId":"ccb62158e97068cc05b2f0927a8acde14c64d0d363cc448238357fe221a39699","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":192697899}
+        ,{"Created":1414108412,"Id":"ccb62158e97068cc05b2f0927a8acde14c64d0d363cc448238357fe221a39699","ParentId":"d497ad3926c8997e1e0de74cdd5285489bb2c4acd6db15292e04bbab07047cd0","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":194791,"VirtualSize":192697899}
+        ,{"Created":1413872056,"Id":"d497ad3926c8997e1e0de74cdd5285489bb2c4acd6db15292e04bbab07047cd0","ParentId":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":192503108,"VirtualSize":192503108}
+        ,{"Created":1412204406,"Id":"f6d75c7fe58a905c14381100921562877d06a759acc70fbda6d3863796e0f003","ParentId":"b083996910428bc46e25ad7c7c0d5dd84c8ced88fe0cceeafe01787d9abd8848","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":6614587,"VirtualSize":425509943}
+        ,{"Created":1412204399,"Id":"b083996910428bc46e25ad7c7c0d5dd84c8ced88fe0cceeafe01787d9abd8848","ParentId":"c07f578f0911d8a712ae9e6909f8778fae749d0dabf65542aba8428c553388ac","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":10478,"VirtualSize":418895356}
+        ,{"Created":1412204376,"Id":"c07f578f0911d8a712ae9e6909f8778fae749d0dabf65542aba8428c553388ac","ParentId":"195eb90b534950d334188c3627f860fbdf898e224d8a0a11ec54ff453175e081","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":234168708,"VirtualSize":418884878}
+        ,{"Created":1412196370,"Id":"d415c60e5ea32875e4ddc7f7578bfaac3d59fb16e1334e705398b10ee91af801","ParentId":"0dfaa2625e19b0925a9e0fc7ea2c2a7f4fd0d31ec1e9838d08bf1310965ffc75","RepoTags":["busybox:ubuntu-12.04"],"Size":0,"VirtualSize":5454693}
+        ,{"Created":1412196370,"Id":"0dfaa2625e19b0925a9e0fc7ea2c2a7f4fd0d31ec1e9838d08bf1310965ffc75","ParentId":"df7546f9f060a2268024c8a230d8639878585defcc1bc6f79d2728a13957871b","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":5454693,"VirtualSize":5454693}
+        ,{"Created":1412196368,"Id":"e72ac664f4f0c6a061ac4ef332557a70d69b0c624b6add35f1c181ff7fff2287","ParentId":"e433a6c5b276a31aa38bf6eaba9cd1cfd69ea33f706ed72b3f20bafde5cd8644","RepoTags":["busybox:buildroot-2014.02","busybox:latest"],"Size":0,"VirtualSize":2433303}
+        ,{"Created":1412196368,"Id":"e433a6c5b276a31aa38bf6eaba9cd1cfd69ea33f706ed72b3f20bafde5cd8644","ParentId":"df7546f9f060a2268024c8a230d8639878585defcc1bc6f79d2728a13957871b","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":2433303,"VirtualSize":2433303}
+        ,{"Created":1412196367,"Id":"4b2909447dbef01f71ca476725c2dbb3af12de41aa2d7491d62c66678ede2294","ParentId":"ad8766e8635d2ae9ddd77d32b8f0fa091fb88fffed77b3a8a240bdcdc6f5aa05","RepoTags":["busybox:buildroot-2013.08.1"],"Size":0,"VirtualSize":2489301}
+        ,{"Created":1412196367,"Id":"df7546f9f060a2268024c8a230d8639878585defcc1bc6f79d2728a13957871b","ParentId":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":0}
+        ,{"Created":1412196367,"Id":"ad8766e8635d2ae9ddd77d32b8f0fa091fb88fffed77b3a8a240bdcdc6f5aa05","ParentId":"df7546f9f060a2268024c8a230d8639878585defcc1bc6f79d2728a13957871b","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":2489301,"VirtualSize":2489301}
+        ,{"Created":1403128415,"Id":"195eb90b534950d334188c3627f860fbdf898e224d8a0a11ec54ff453175e081","ParentId":"209ea56fda6dc2fb013e4d1e40cb678b2af91d1b54a71529f7df0bd867adc961","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":4411741,"VirtualSize":184716170}
+        ,{"Created":1403128408,"Id":"209ea56fda6dc2fb013e4d1e40cb678b2af91d1b54a71529f7df0bd867adc961","ParentId":"0f4aac48388f5d65a725ccf8e7caada42f136026c566528a5ee9b02467dac90a","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":74007417,"VirtualSize":180304429}
+        ,{"Created":1403128396,"Id":"0f4aac48388f5d65a725ccf8e7caada42f136026c566528a5ee9b02467dac90a","ParentId":"fae16849ebe23b48f2bedcc08aaabd45408c62b531ffd8d3088592043d5e7364","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1887,"VirtualSize":106297012}
+        ,{"Created":1403128396,"Id":"fae16849ebe23b48f2bedcc08aaabd45408c62b531ffd8d3088592043d5e7364","ParentId":"f127542f0b6191e99bb015b672f5cf48fa79d974784ac8090b11aeac184eaaff","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":189999,"VirtualSize":106295125}
+        ,{"Created":1403128393,"Id":"f127542f0b6191e99bb015b672f5cf48fa79d974784ac8090b11aeac184eaaff","ParentId":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":106105126,"VirtualSize":106105126}
+        ,{"Created":1371157430,"Id":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","ParentId":"","RepoTags":["scratch:latest"],"Size":0,"VirtualSize":0}
+        ]
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:44 GMT
+- request:
+    method: get
+    uri: "<DOCKER_HOST>/v1.15/images/b239f80471db/json"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Dec 2014 18:08:44 GMT
+      Content-Length:
+      - '1451'
+    body:
+      encoding: UTF-8
+      string: |
+        {"Architecture":"amd64","Author":"","Comment":"","Config":{"AttachStderr":false,"AttachStdin":false,"AttachStdout":false,"Cmd":["/true"],"CpuShares":0,"Cpuset":"","Domainname":"","Entrypoint":null,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","TRIVIAL=CHANGE"],"ExposedPorts":null,"Hostname":"0d1fedb580de","Image":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","Memory":0,"MemorySwap":0,"NetworkDisabled":false,"OnBuild":[],"OpenStdin":false,"PortSpecs":null,"SecurityOpt":null,"StdinOnce":false,"Tty":false,"User":"","Volumes":null,"WorkingDir":""},"Container":"6d0c01400c38e0783f2be9f22d9ef47c1e8b56fa83085d4d7ea360e94916640f","ContainerConfig":{"AttachStderr":false,"AttachStdin":false,"AttachStdout":false,"Cmd":["/bin/sh","-c","#(nop) ENV TRIVIAL=CHANGE"],"CpuShares":0,"Cpuset":"","Domainname":"","Entrypoint":null,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","TRIVIAL=CHANGE"],"ExposedPorts":null,"Hostname":"0d1fedb580de","Image":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","Memory":0,"MemorySwap":0,"NetworkDisabled":false,"OnBuild":[],"OpenStdin":false,"PortSpecs":null,"SecurityOpt":null,"StdinOnce":false,"Tty":false,"User":"","Volumes":null,"WorkingDir":""},"Created":"2014-12-10T02:32:41.527606628Z","DockerVersion":"1.3.1","Id":"b239f80471dbc0ee17ca34e648e4cc0b1013c740bccb621d6ad00edbc3f26dc7","Os":"linux","Parent":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","Size":0,"VirtualSize":125}
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:44 GMT
+- request:
+    method: delete
+    uri: "<DOCKER_HOST>/v1.15/images/<USERNAME>/true?noprune=true"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Dec 2014 18:08:45 GMT
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: |-
+        [{"Untagged":"<USERNAME>/true:latest"}
+        ]
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:45 GMT
+recorded_with: VCR 2.9.3

--- a/spec/vcr/Docker_Image/_push/raises_an_error_if_not_found.yml
+++ b/spec/vcr/Docker_Image/_push/raises_an_error_if_not_found.yml
@@ -1,0 +1,318 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<DOCKER_HOST>/v1.15/build?t=<USERNAME>%2Ftrue"
+    body:
+      encoding: UTF-8
+      string: !binary |-
+        RG9ja2VyZmlsZQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAADAwMDA2NDAAMDAwMDAwMAAwMDAwMDAwADAwMDAwMDAwMDIx
+        ADEyNDM3MTI3MjU0ADAxMzMwNAAgMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB1c3RhcgAwMHdoZWVs
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAd2hlZWwAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAwMDAwMDAwADAwMDAwMDAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAABGUk9NIHRpYW5vbi90cnVlCgAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Dec 2014 18:08:44 GMT
+    body:
+      encoding: UTF-8
+      string: "{\"stream\":\"Step 0 : FROM tianon/true\\n\"}\r\n{\"stream\":\" ---\\u003e
+        69e7aca3d78e\\n\"}\r\n{\"stream\":\"Step 1 : ENV TRIVIAL CHANGE\\n\"}\r\n{\"stream\":\"
+        ---\\u003e Running in 6d0c01400c38\\n\"}\r\n{\"stream\":\" ---\\u003e b239f80471db\\n\"}\r\n{\"stream\":\"Removing
+        intermediate container 6d0c01400c38\\n\"}\r\n{\"stream\":\"Successfully built
+        b239f80471db\\n\"}\r\n"
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:44 GMT
+- request:
+    method: get
+    uri: "<DOCKER_HOST>/v1.15/images/json?all=true"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Dec 2014 18:08:44 GMT
+    body:
+      encoding: UTF-8
+      string: |-
+        [{"Created":1418178761,"Id":"b239f80471dbc0ee17ca34e648e4cc0b1013c740bccb621d6ad00edbc3f26dc7","ParentId":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","RepoTags":["<USERNAME>/true:latest"],"Size":0,"VirtualSize":125}
+        ,{"Created":1417805428,"Id":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","ParentId":"9d182a4ffb01e4ecfc5397bf9a989016e7ae6920f6e64a037db4c0a2f3c0e264","RepoTags":["tianon/true:latest"],"Size":0,"VirtualSize":125}
+        ,{"Created":1416799251,"Id":"0b7a3c1fbea815d721ccf5404d05e0d8c667945ebe21acdf530fae3aa22184ce","ParentId":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":125,"VirtualSize":125}
+        ,{"Created":1415864019,"Id":"74f5b38a45c97043cdf0082b8e8dd002497ab6b03388cdb2f20bafb7468ad55b","ParentId":"31ae66be94f160a92e1e757ab9a66aa7183af55183080576fb93a52cbce9e0cd","RepoTags":["registry:0.9.0"],"Size":0,"VirtualSize":411649756}
+        ,{"Created":1415864018,"Id":"31ae66be94f160a92e1e757ab9a66aa7183af55183080576fb93a52cbce9e0cd","ParentId":"b3fd13d94685095ec1c1f8f0f371dde8be9a21f8f457d4d10e5ad72042a152af","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649756}
+        ,{"Created":1415864017,"Id":"eae8be82bb623181222558e4df0dd59c943cdc2fd3c4e41de669e4bd35a866e6","ParentId":"8eae38b276496440046cd9f545c24533e692cbed6fd1bc4e29a7af5e4ae72a61","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649756}
+        ,{"Created":1415864017,"Id":"b3fd13d94685095ec1c1f8f0f371dde8be9a21f8f457d4d10e5ad72042a152af","ParentId":"eae8be82bb623181222558e4df0dd59c943cdc2fd3c4e41de669e4bd35a866e6","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649756}
+        ,{"Created":1415864016,"Id":"8eae38b276496440046cd9f545c24533e692cbed6fd1bc4e29a7af5e4ae72a61","ParentId":"16b02bf8dc3d1f70e098cbd968f154468fcf41be6bf59b24a35b4fdded3edbca","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":50796,"VirtualSize":411649756}
+        ,{"Created":1415864015,"Id":"16b02bf8dc3d1f70e098cbd968f154468fcf41be6bf59b24a35b4fdded3edbca","ParentId":"b22cb7ed5ccbeeaf2a67d5d3034a308c6eedf2ccb247851c9a14c05b441716fa","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":23990121,"VirtualSize":411598960}
+        ,{"Created":1415863862,"Id":"b22cb7ed5ccbeeaf2a67d5d3034a308c6eedf2ccb247851c9a14c05b441716fa","ParentId":"8b170afd480f41a84331dcaabfa6465769205e645ba13f8baa085f1f68e4f1cf","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":11550557,"VirtualSize":387608839}
+        ,{"Created":1415863855,"Id":"8b170afd480f41a84331dcaabfa6465769205e645ba13f8baa085f1f68e4f1cf","ParentId":"8dda8bb23254979ce24f2ca4d7115f4563a9ae4f0e774b2d419318d81a5c720d","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":73,"VirtualSize":376058282}
+        ,{"Created":1415863853,"Id":"8dda8bb23254979ce24f2ca4d7115f4563a9ae4f0e774b2d419318d81a5c720d","ParentId":"7d49ba12f2de52ae8dfec8c661f4471e00d546b57adc3913cefc56f89b932e22","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1880042,"VirtualSize":376058209}
+        ,{"Created":1415863849,"Id":"d9925ba888d4dba2d9b22273d261155fe3b2a4e6cfa5db44e4abe5ac8e311efa","ParentId":"4abfff610473315c2fb7a6278c924948ba877fe6630ad197f734572b7636188e","RepoTags":["registry:0.8.1"],"Size":0,"VirtualSize":430388853}
+        ,{"Created":1415863848,"Id":"4abfff610473315c2fb7a6278c924948ba877fe6630ad197f734572b7636188e","ParentId":"8b840022b4b5d60e0f66d7f72b992eb5b52e75dfdf1b8e9535d85df57236e7f5","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":430388853}
+        ,{"Created":1415863847,"Id":"8b840022b4b5d60e0f66d7f72b992eb5b52e75dfdf1b8e9535d85df57236e7f5","ParentId":"11d3a913c69b0ea1c7d0df3708dfa8c789b68dc0884471cf862de1160c7eaaba","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":430388853}
+        ,{"Created":1415863846,"Id":"11d3a913c69b0ea1c7d0df3708dfa8c789b68dc0884471cf862de1160c7eaaba","ParentId":"ae88728b911af97e928890b1c3b7b34dd25fb313f3b20cd73e532e2903d3d3b9","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":430388853}
+        ,{"Created":1415863845,"Id":"ae88728b911af97e928890b1c3b7b34dd25fb313f3b20cd73e532e2903d3d3b9","ParentId":"16c101215b54ac2210fa62d54e0893323ae43e3d33b75119b1246a9dbbc1c7cf","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":23901352,"VirtualSize":430388853}
+        ,{"Created":1415863690,"Id":"16c101215b54ac2210fa62d54e0893323ae43e3d33b75119b1246a9dbbc1c7cf","ParentId":"4c86ccffaf465d6688815f844bfadbb91a76df42043e629d208c5b75de31b891","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":8442747,"VirtualSize":406487501}
+        ,{"Created":1415863686,"Id":"4c86ccffaf465d6688815f844bfadbb91a76df42043e629d208c5b75de31b891","ParentId":"e930198c27c4d790fd3eece5212c7ab1e6f272bfd21061c877b38696aa91ac27","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":73,"VirtualSize":398044754}
+        ,{"Created":1415863685,"Id":"e930198c27c4d790fd3eece5212c7ab1e6f272bfd21061c877b38696aa91ac27","ParentId":"6ffb25246d5531cdbf15ac250dcf0d10fca544944eaf7386b4cff8577488f258","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1861177,"VirtualSize":398044681}
+        ,{"Created":1415863681,"Id":"7e2db37c6564bf030e6c5af9725bf9f9a8196846e3a77a51e201fc97871e2e60","ParentId":"765d6041baaa23390504094a101b8f4e3433e99a03cb0f5cf20e3b2e3a2a7523","RepoTags":["registry:latest"],"Size":0,"VirtualSize":411649320}
+        ,{"Created":1415863680,"Id":"765d6041baaa23390504094a101b8f4e3433e99a03cb0f5cf20e3b2e3a2a7523","ParentId":"c978e4c4261aec2dbc24c84427460afdaeaa64359ff4ed0ad6d4d00f0e0e0cd7","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649320}
+        ,{"Created":1415863680,"Id":"c978e4c4261aec2dbc24c84427460afdaeaa64359ff4ed0ad6d4d00f0e0e0cd7","ParentId":"f846b2ccf2c5679f8d95014285a8e771441b5e5fc04670e0dfcb1242e985eb5e","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649320}
+        ,{"Created":1415863679,"Id":"7949c9f83980aab0ac80e3150c0d3f899556c68f35d8f6f9ca7c79ecb769b70e","ParentId":"e8ca0e3bcd941b41c0c3dabebdb545f8331ddbb25257e6bc2cd3b6e6233d64f5","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":50796,"VirtualSize":411649320}
+        ,{"Created":1415863679,"Id":"f846b2ccf2c5679f8d95014285a8e771441b5e5fc04670e0dfcb1242e985eb5e","ParentId":"7949c9f83980aab0ac80e3150c0d3f899556c68f35d8f6f9ca7c79ecb769b70e","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649320}
+        ,{"Created":1415863677,"Id":"e8ca0e3bcd941b41c0c3dabebdb545f8331ddbb25257e6bc2cd3b6e6233d64f5","ParentId":"d242d0f728d9aaec3a24215bd3f6fc85a365f36bbb97727a84d5de7cc45792c4","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":23990121,"VirtualSize":411598524}
+        ,{"Created":1415863518,"Id":"d242d0f728d9aaec3a24215bd3f6fc85a365f36bbb97727a84d5de7cc45792c4","ParentId":"b3b586534b2a68b97cec6e3d676fe1b2a1713565929c7e9ff331aad04eaf83cb","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":11550557,"VirtualSize":387608403}
+        ,{"Created":1415863510,"Id":"b3b586534b2a68b97cec6e3d676fe1b2a1713565929c7e9ff331aad04eaf83cb","ParentId":"1ac06968b34e2b5b7c4e16488a4059f6493018f6744a57cf6a4fd2418f7acc4f","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":73,"VirtualSize":376057846}
+        ,{"Created":1415863509,"Id":"1ac06968b34e2b5b7c4e16488a4059f6493018f6744a57cf6a4fd2418f7acc4f","ParentId":"7d49ba12f2de52ae8dfec8c661f4471e00d546b57adc3913cefc56f89b932e22","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1879606,"VirtualSize":376057773}
+        ,{"Created":1415309161,"Id":"7d49ba12f2de52ae8dfec8c661f4471e00d546b57adc3913cefc56f89b932e22","ParentId":"5506de2b643be1e6febbf3b8a240760c6843244c41e12aa2f60ccbb7153d17f5","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":174920601,"VirtualSize":374178167}
+        ,{"Created":1415306638,"Id":"f6fab3b798be3174f45aa1eb731f8182705555f89c9026d8c1ef230cbf8301dd","ParentId":"f10807909bc552de261ca7463effc467600c3dca68d8e7704425283a6911d2ca","RepoTags":["debian:wheezy"],"Size":0,"VirtualSize":85100505}
+        ,{"Created":1415306636,"Id":"f10807909bc552de261ca7463effc467600c3dca68d8e7704425283a6911d2ca","ParentId":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":85100505,"VirtualSize":85100505}
+        ,{"Created":1414177799,"Id":"c723c9b95ac05c29c3e96b0b02e8fcf12096d850306b776a17877ee061daf49f","ParentId":"74dc9d28a649ac161e2a70d84190fe576f77f403f2565012f07bd68d638d291a","RepoTags":["registry:0.7.3"],"Size":0,"VirtualSize":426413472}
+        ,{"Created":1414177799,"Id":"74dc9d28a649ac161e2a70d84190fe576f77f403f2565012f07bd68d638d291a","ParentId":"00bcc0fe318f87107ed0db582ed109899506cd2cde230505ea11a5c400e9ac7a","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":426413472}
+        ,{"Created":1414177798,"Id":"00bcc0fe318f87107ed0db582ed109899506cd2cde230505ea11a5c400e9ac7a","ParentId":"96490e2b34642fabcdf6c4c157bd07be2caf4a71b9bd42c27386a1ff28d94d0c","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":426413472}
+        ,{"Created":1414177798,"Id":"96490e2b34642fabcdf6c4c157bd07be2caf4a71b9bd42c27386a1ff28d94d0c","ParentId":"1168ef7bd438745360d3506a6182ed73fec60bfea4181732dd75d6447016f012","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":426413472}
+        ,{"Created":1414177797,"Id":"1168ef7bd438745360d3506a6182ed73fec60bfea4181732dd75d6447016f012","ParentId":"a9c8dae074b96475a0775e199f79e456f0ee9a8288164e0b84fcc65ca163432e","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":20135062,"VirtualSize":426413472}
+        ,{"Created":1414177667,"Id":"a9c8dae074b96475a0775e199f79e456f0ee9a8288164e0b84fcc65ca163432e","ParentId":"17b869d7773564fa1ca26ef3aa5b3a9e615dabd1a433a4a00848c0c9790096fe","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":8437018,"VirtualSize":406278410}
+        ,{"Created":1414177663,"Id":"17b869d7773564fa1ca26ef3aa5b3a9e615dabd1a433a4a00848c0c9790096fe","ParentId":"4627c1e0f2389a25dce44361dba566542607509b4fec86cc7fae9f6bb93dc2eb","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":73,"VirtualSize":397841392}
+        ,{"Created":1414177663,"Id":"4627c1e0f2389a25dce44361dba566542607509b4fec86cc7fae9f6bb93dc2eb","ParentId":"6ffb25246d5531cdbf15ac250dcf0d10fca544944eaf7386b4cff8577488f258","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1657815,"VirtualSize":397841319}
+        ,{"Created":1414174623,"Id":"881f05ab63649f7d4b4ab048a2e01725c6a2d45f8866807bdb7766e28cdf224e","ParentId":"74583b71c35c28e06e11e0af0193351b852f3e9466a7b2c19a3add9a8528ee57","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":462038905}
+        ,{"Created":1414174623,"Id":"bee70978874ce288a546770e762196041c90d5b0c0ef7e0c3d2e551d79417701","ParentId":"881f05ab63649f7d4b4ab048a2e01725c6a2d45f8866807bdb7766e28cdf224e","RepoTags":["registry:0.6.9"],"Size":0,"VirtualSize":462038905}
+        ,{"Created":1414174623,"Id":"74583b71c35c28e06e11e0af0193351b852f3e9466a7b2c19a3add9a8528ee57","ParentId":"0909821a1551e63f5b169edaa3fa460134d86aa0ed5e6ed3acb4f50afa98002d","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":462038905}
+        ,{"Created":1414174622,"Id":"0909821a1551e63f5b169edaa3fa460134d86aa0ed5e6ed3acb4f50afa98002d","ParentId":"ad702f54c76e4d5e1fb47f9efc355c871f7087ae772ca0fafeedad8185d17058","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":34915187,"VirtualSize":462038905}
+        ,{"Created":1414174578,"Id":"29b16b1bfd162dd7b35cb98a72ad44108361bede4e42679e01dd8aa15aa1fe0f","ParentId":"f6d75c7fe58a905c14381100921562877d06a759acc70fbda6d3863796e0f003","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1613702,"VirtualSize":427123645}
+        ,{"Created":1414174578,"Id":"ad702f54c76e4d5e1fb47f9efc355c871f7087ae772ca0fafeedad8185d17058","ParentId":"29b16b1bfd162dd7b35cb98a72ad44108361bede4e42679e01dd8aa15aa1fe0f","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":73,"VirtualSize":427123718}
+        ,{"Created":1414126280,"Id":"6ffb25246d5531cdbf15ac250dcf0d10fca544944eaf7386b4cff8577488f258","ParentId":"9fe54074b35a3dd77eb2ffe2edf9226645e71fe292964b6d662a4010e695d9b8","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":41247201,"VirtualSize":396183504}
+        ,{"Created":1414126257,"Id":"9fe54074b35a3dd77eb2ffe2edf9226645e71fe292964b6d662a4010e695d9b8","ParentId":"cd72e4fcfd16a48d617cc8fe6c692400b55c3dd013a357f485a08a820f1f75ab","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":135294909,"VirtualSize":354936303}
+        ,{"Created":1414126216,"Id":"cd72e4fcfd16a48d617cc8fe6c692400b55c3dd013a357f485a08a820f1f75ab","ParentId":"57b5d5cb0bfe239f714f9a00439d7774f3b3359270f81ea74b41dbd7775eb46a","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":219641394}
+        ,{"Created":1414126211,"Id":"57b5d5cb0bfe239f714f9a00439d7774f3b3359270f81ea74b41dbd7775eb46a","ParentId":"5506de2b643be1e6febbf3b8a240760c6843244c41e12aa2f60ccbb7153d17f5","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":20383828,"VirtualSize":219641394}
+        ,{"Created":1414108439,"Id":"5506de2b643be1e6febbf3b8a240760c6843244c41e12aa2f60ccbb7153d17f5","ParentId":"22093c35d77bb609b9257ffb2640845ec05018e3d96cb939f68d0e19127f1723","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":199257566}
+        ,{"Created":1414108438,"Id":"22093c35d77bb609b9257ffb2640845ec05018e3d96cb939f68d0e19127f1723","ParentId":"3680052c0f5cf8ecb86ddf4d6ed331c89cdb691554572a80ec04724cf6ee9436","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":6557772,"VirtualSize":199257566}
+        ,{"Created":1414108414,"Id":"3680052c0f5cf8ecb86ddf4d6ed331c89cdb691554572a80ec04724cf6ee9436","ParentId":"e791be0477f28fd52f7609aed81733427d4cc0da620962d072e18ebcb32720a4","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1895,"VirtualSize":192699794}
+        ,{"Created":1414108413,"Id":"e791be0477f28fd52f7609aed81733427d4cc0da620962d072e18ebcb32720a4","ParentId":"ccb62158e97068cc05b2f0927a8acde14c64d0d363cc448238357fe221a39699","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":192697899}
+        ,{"Created":1414108412,"Id":"ccb62158e97068cc05b2f0927a8acde14c64d0d363cc448238357fe221a39699","ParentId":"d497ad3926c8997e1e0de74cdd5285489bb2c4acd6db15292e04bbab07047cd0","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":194791,"VirtualSize":192697899}
+        ,{"Created":1413872056,"Id":"d497ad3926c8997e1e0de74cdd5285489bb2c4acd6db15292e04bbab07047cd0","ParentId":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":192503108,"VirtualSize":192503108}
+        ,{"Created":1412204406,"Id":"f6d75c7fe58a905c14381100921562877d06a759acc70fbda6d3863796e0f003","ParentId":"b083996910428bc46e25ad7c7c0d5dd84c8ced88fe0cceeafe01787d9abd8848","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":6614587,"VirtualSize":425509943}
+        ,{"Created":1412204399,"Id":"b083996910428bc46e25ad7c7c0d5dd84c8ced88fe0cceeafe01787d9abd8848","ParentId":"c07f578f0911d8a712ae9e6909f8778fae749d0dabf65542aba8428c553388ac","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":10478,"VirtualSize":418895356}
+        ,{"Created":1412204376,"Id":"c07f578f0911d8a712ae9e6909f8778fae749d0dabf65542aba8428c553388ac","ParentId":"195eb90b534950d334188c3627f860fbdf898e224d8a0a11ec54ff453175e081","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":234168708,"VirtualSize":418884878}
+        ,{"Created":1412196370,"Id":"d415c60e5ea32875e4ddc7f7578bfaac3d59fb16e1334e705398b10ee91af801","ParentId":"0dfaa2625e19b0925a9e0fc7ea2c2a7f4fd0d31ec1e9838d08bf1310965ffc75","RepoTags":["busybox:ubuntu-12.04"],"Size":0,"VirtualSize":5454693}
+        ,{"Created":1412196370,"Id":"0dfaa2625e19b0925a9e0fc7ea2c2a7f4fd0d31ec1e9838d08bf1310965ffc75","ParentId":"df7546f9f060a2268024c8a230d8639878585defcc1bc6f79d2728a13957871b","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":5454693,"VirtualSize":5454693}
+        ,{"Created":1412196368,"Id":"e72ac664f4f0c6a061ac4ef332557a70d69b0c624b6add35f1c181ff7fff2287","ParentId":"e433a6c5b276a31aa38bf6eaba9cd1cfd69ea33f706ed72b3f20bafde5cd8644","RepoTags":["busybox:buildroot-2014.02","busybox:latest"],"Size":0,"VirtualSize":2433303}
+        ,{"Created":1412196368,"Id":"e433a6c5b276a31aa38bf6eaba9cd1cfd69ea33f706ed72b3f20bafde5cd8644","ParentId":"df7546f9f060a2268024c8a230d8639878585defcc1bc6f79d2728a13957871b","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":2433303,"VirtualSize":2433303}
+        ,{"Created":1412196367,"Id":"4b2909447dbef01f71ca476725c2dbb3af12de41aa2d7491d62c66678ede2294","ParentId":"ad8766e8635d2ae9ddd77d32b8f0fa091fb88fffed77b3a8a240bdcdc6f5aa05","RepoTags":["busybox:buildroot-2013.08.1"],"Size":0,"VirtualSize":2489301}
+        ,{"Created":1412196367,"Id":"df7546f9f060a2268024c8a230d8639878585defcc1bc6f79d2728a13957871b","ParentId":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":0}
+        ,{"Created":1412196367,"Id":"ad8766e8635d2ae9ddd77d32b8f0fa091fb88fffed77b3a8a240bdcdc6f5aa05","ParentId":"df7546f9f060a2268024c8a230d8639878585defcc1bc6f79d2728a13957871b","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":2489301,"VirtualSize":2489301}
+        ,{"Created":1403128415,"Id":"195eb90b534950d334188c3627f860fbdf898e224d8a0a11ec54ff453175e081","ParentId":"209ea56fda6dc2fb013e4d1e40cb678b2af91d1b54a71529f7df0bd867adc961","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":4411741,"VirtualSize":184716170}
+        ,{"Created":1403128408,"Id":"209ea56fda6dc2fb013e4d1e40cb678b2af91d1b54a71529f7df0bd867adc961","ParentId":"0f4aac48388f5d65a725ccf8e7caada42f136026c566528a5ee9b02467dac90a","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":74007417,"VirtualSize":180304429}
+        ,{"Created":1403128396,"Id":"0f4aac48388f5d65a725ccf8e7caada42f136026c566528a5ee9b02467dac90a","ParentId":"fae16849ebe23b48f2bedcc08aaabd45408c62b531ffd8d3088592043d5e7364","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1887,"VirtualSize":106297012}
+        ,{"Created":1403128396,"Id":"fae16849ebe23b48f2bedcc08aaabd45408c62b531ffd8d3088592043d5e7364","ParentId":"f127542f0b6191e99bb015b672f5cf48fa79d974784ac8090b11aeac184eaaff","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":189999,"VirtualSize":106295125}
+        ,{"Created":1403128393,"Id":"f127542f0b6191e99bb015b672f5cf48fa79d974784ac8090b11aeac184eaaff","ParentId":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":106105126,"VirtualSize":106105126}
+        ,{"Created":1371157430,"Id":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","ParentId":"","RepoTags":["scratch:latest"],"Size":0,"VirtualSize":0}
+        ]
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:44 GMT
+- request:
+    method: get
+    uri: "<DOCKER_HOST>/v1.15/images/b239f80471db/json"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Dec 2014 18:08:44 GMT
+      Content-Length:
+      - '1451'
+    body:
+      encoding: UTF-8
+      string: |
+        {"Architecture":"amd64","Author":"","Comment":"","Config":{"AttachStderr":false,"AttachStdin":false,"AttachStdout":false,"Cmd":["/true"],"CpuShares":0,"Cpuset":"","Domainname":"","Entrypoint":null,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","TRIVIAL=CHANGE"],"ExposedPorts":null,"Hostname":"0d1fedb580de","Image":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","Memory":0,"MemorySwap":0,"NetworkDisabled":false,"OnBuild":[],"OpenStdin":false,"PortSpecs":null,"SecurityOpt":null,"StdinOnce":false,"Tty":false,"User":"","Volumes":null,"WorkingDir":""},"Container":"6d0c01400c38e0783f2be9f22d9ef47c1e8b56fa83085d4d7ea360e94916640f","ContainerConfig":{"AttachStderr":false,"AttachStdin":false,"AttachStdout":false,"Cmd":["/bin/sh","-c","#(nop) ENV TRIVIAL=CHANGE"],"CpuShares":0,"Cpuset":"","Domainname":"","Entrypoint":null,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","TRIVIAL=CHANGE"],"ExposedPorts":null,"Hostname":"0d1fedb580de","Image":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","Memory":0,"MemorySwap":0,"NetworkDisabled":false,"OnBuild":[],"OpenStdin":false,"PortSpecs":null,"SecurityOpt":null,"StdinOnce":false,"Tty":false,"User":"","Volumes":null,"WorkingDir":""},"Created":"2014-12-10T02:32:41.527606628Z","DockerVersion":"1.3.1","Id":"b239f80471dbc0ee17ca34e648e4cc0b1013c740bccb621d6ad00edbc3f26dc7","Os":"linux","Parent":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","Size":0,"VirtualSize":125}
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:44 GMT
+- request:
+    method: post
+    uri: "<DOCKER_HOST>/v1.15/images/b239f80471db/tag?repo=<USERNAME>%2Ftrue&tag=also"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 201
+      message: 
+    headers:
+      Date:
+      - Mon, 01 Dec 2014 18:08:44 GMT
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/plain; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:44 GMT
+- request:
+    method: delete
+    uri: "<DOCKER_HOST>/v1.15/images/<USERNAME>/true:also?noprune=true"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Dec 2014 18:08:45 GMT
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: |-
+        [{"Untagged":"<USERNAME>/true:latest"}
+        ]
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:45 GMT
+- request:
+    method: post
+    uri: "<DOCKER_HOST>/v1.15/images/<USERNAME>/true/push?tag=also"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - text/plain
+      X-Registry-Auth:
+      - eyJ1c2VybmFtZSI6InRkdWZmaWVsZCIsInBhc3N3b3JkIjoiaTlCZj5KZ3ZmYmpZL3NKV01jVTkiLCJzZXJ2ZXJhZGRyZXNzIjoiaHR0cHM6Ly9pbmRleC5kb2NrZXIuaW8vdjEiLCJlbWFpbCI6ImdpdGh1YkB0b21kdWZmaWVsZC5jb20ifQ==
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Dec 2014 18:08:44 GMT
+    body:
+      encoding: UTF-8
+      string: "{\"status\":\"The push refers to a repository [<USERNAME>/true] (len:
+        1)\"}\r\n{\"errorDetail\":{\"message\":\"No such id: <USERNAME>/true\"},\"error\":\"No
+        such id: <USERNAME>/true\"}\r\n"
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:45 GMT
+- request:
+    method: delete
+    uri: "<DOCKER_HOST>/v1.15/images/<USERNAME>/true?noprune=true"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Dec 2014 18:08:45 GMT
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: |-
+        [{"Untagged":"<USERNAME>/true:latest"}
+        ]
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:45 GMT
+recorded_with: VCR 2.9.3

--- a/spec/vcr/Docker_Image/_push/raises_an_error_if_unauthorized.yml
+++ b/spec/vcr/Docker_Image/_push/raises_an_error_if_unauthorized.yml
@@ -1,0 +1,263 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<DOCKER_HOST>/v1.15/build?t=<USERNAME>%2Ftrue"
+    body:
+      encoding: UTF-8
+      string: !binary |-
+        RG9ja2VyZmlsZQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAADAwMDA2NDAAMDAwMDAwMAAwMDAwMDAwADAwMDAwMDAwMDIx
+        ADEyNDM3MTI3MjU0ADAxMzMwNAAgMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB1c3RhcgAwMHdoZWVs
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAd2hlZWwAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAwMDAwMDAwADAwMDAwMDAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAABGUk9NIHRpYW5vbi90cnVlCgAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Dec 2014 18:08:44 GMT
+    body:
+      encoding: UTF-8
+      string: "{\"stream\":\"Step 0 : FROM tianon/true\\n\"}\r\n{\"stream\":\" ---\\u003e
+        69e7aca3d78e\\n\"}\r\n{\"stream\":\"Step 1 : ENV TRIVIAL CHANGE\\n\"}\r\n{\"stream\":\"
+        ---\\u003e Running in 6d0c01400c38\\n\"}\r\n{\"stream\":\" ---\\u003e b239f80471db\\n\"}\r\n{\"stream\":\"Removing
+        intermediate container 6d0c01400c38\\n\"}\r\n{\"stream\":\"Successfully built
+        b239f80471db\\n\"}\r\n"
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:44 GMT
+- request:
+    method: get
+    uri: "<DOCKER_HOST>/v1.15/images/json?all=true"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Dec 2014 18:08:44 GMT
+    body:
+      encoding: UTF-8
+      string: |-
+        [{"Created":1418178761,"Id":"b239f80471dbc0ee17ca34e648e4cc0b1013c740bccb621d6ad00edbc3f26dc7","ParentId":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","RepoTags":["<USERNAME>/true:latest"],"Size":0,"VirtualSize":125}
+        ,{"Created":1417805428,"Id":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","ParentId":"9d182a4ffb01e4ecfc5397bf9a989016e7ae6920f6e64a037db4c0a2f3c0e264","RepoTags":["tianon/true:latest"],"Size":0,"VirtualSize":125}
+        ,{"Created":1416799251,"Id":"0b7a3c1fbea815d721ccf5404d05e0d8c667945ebe21acdf530fae3aa22184ce","ParentId":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":125,"VirtualSize":125}
+        ,{"Created":1415864019,"Id":"74f5b38a45c97043cdf0082b8e8dd002497ab6b03388cdb2f20bafb7468ad55b","ParentId":"31ae66be94f160a92e1e757ab9a66aa7183af55183080576fb93a52cbce9e0cd","RepoTags":["registry:0.9.0"],"Size":0,"VirtualSize":411649756}
+        ,{"Created":1415864018,"Id":"31ae66be94f160a92e1e757ab9a66aa7183af55183080576fb93a52cbce9e0cd","ParentId":"b3fd13d94685095ec1c1f8f0f371dde8be9a21f8f457d4d10e5ad72042a152af","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649756}
+        ,{"Created":1415864017,"Id":"eae8be82bb623181222558e4df0dd59c943cdc2fd3c4e41de669e4bd35a866e6","ParentId":"8eae38b276496440046cd9f545c24533e692cbed6fd1bc4e29a7af5e4ae72a61","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649756}
+        ,{"Created":1415864017,"Id":"b3fd13d94685095ec1c1f8f0f371dde8be9a21f8f457d4d10e5ad72042a152af","ParentId":"eae8be82bb623181222558e4df0dd59c943cdc2fd3c4e41de669e4bd35a866e6","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649756}
+        ,{"Created":1415864016,"Id":"8eae38b276496440046cd9f545c24533e692cbed6fd1bc4e29a7af5e4ae72a61","ParentId":"16b02bf8dc3d1f70e098cbd968f154468fcf41be6bf59b24a35b4fdded3edbca","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":50796,"VirtualSize":411649756}
+        ,{"Created":1415864015,"Id":"16b02bf8dc3d1f70e098cbd968f154468fcf41be6bf59b24a35b4fdded3edbca","ParentId":"b22cb7ed5ccbeeaf2a67d5d3034a308c6eedf2ccb247851c9a14c05b441716fa","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":23990121,"VirtualSize":411598960}
+        ,{"Created":1415863862,"Id":"b22cb7ed5ccbeeaf2a67d5d3034a308c6eedf2ccb247851c9a14c05b441716fa","ParentId":"8b170afd480f41a84331dcaabfa6465769205e645ba13f8baa085f1f68e4f1cf","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":11550557,"VirtualSize":387608839}
+        ,{"Created":1415863855,"Id":"8b170afd480f41a84331dcaabfa6465769205e645ba13f8baa085f1f68e4f1cf","ParentId":"8dda8bb23254979ce24f2ca4d7115f4563a9ae4f0e774b2d419318d81a5c720d","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":73,"VirtualSize":376058282}
+        ,{"Created":1415863853,"Id":"8dda8bb23254979ce24f2ca4d7115f4563a9ae4f0e774b2d419318d81a5c720d","ParentId":"7d49ba12f2de52ae8dfec8c661f4471e00d546b57adc3913cefc56f89b932e22","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1880042,"VirtualSize":376058209}
+        ,{"Created":1415863849,"Id":"d9925ba888d4dba2d9b22273d261155fe3b2a4e6cfa5db44e4abe5ac8e311efa","ParentId":"4abfff610473315c2fb7a6278c924948ba877fe6630ad197f734572b7636188e","RepoTags":["registry:0.8.1"],"Size":0,"VirtualSize":430388853}
+        ,{"Created":1415863848,"Id":"4abfff610473315c2fb7a6278c924948ba877fe6630ad197f734572b7636188e","ParentId":"8b840022b4b5d60e0f66d7f72b992eb5b52e75dfdf1b8e9535d85df57236e7f5","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":430388853}
+        ,{"Created":1415863847,"Id":"8b840022b4b5d60e0f66d7f72b992eb5b52e75dfdf1b8e9535d85df57236e7f5","ParentId":"11d3a913c69b0ea1c7d0df3708dfa8c789b68dc0884471cf862de1160c7eaaba","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":430388853}
+        ,{"Created":1415863846,"Id":"11d3a913c69b0ea1c7d0df3708dfa8c789b68dc0884471cf862de1160c7eaaba","ParentId":"ae88728b911af97e928890b1c3b7b34dd25fb313f3b20cd73e532e2903d3d3b9","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":430388853}
+        ,{"Created":1415863845,"Id":"ae88728b911af97e928890b1c3b7b34dd25fb313f3b20cd73e532e2903d3d3b9","ParentId":"16c101215b54ac2210fa62d54e0893323ae43e3d33b75119b1246a9dbbc1c7cf","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":23901352,"VirtualSize":430388853}
+        ,{"Created":1415863690,"Id":"16c101215b54ac2210fa62d54e0893323ae43e3d33b75119b1246a9dbbc1c7cf","ParentId":"4c86ccffaf465d6688815f844bfadbb91a76df42043e629d208c5b75de31b891","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":8442747,"VirtualSize":406487501}
+        ,{"Created":1415863686,"Id":"4c86ccffaf465d6688815f844bfadbb91a76df42043e629d208c5b75de31b891","ParentId":"e930198c27c4d790fd3eece5212c7ab1e6f272bfd21061c877b38696aa91ac27","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":73,"VirtualSize":398044754}
+        ,{"Created":1415863685,"Id":"e930198c27c4d790fd3eece5212c7ab1e6f272bfd21061c877b38696aa91ac27","ParentId":"6ffb25246d5531cdbf15ac250dcf0d10fca544944eaf7386b4cff8577488f258","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1861177,"VirtualSize":398044681}
+        ,{"Created":1415863681,"Id":"7e2db37c6564bf030e6c5af9725bf9f9a8196846e3a77a51e201fc97871e2e60","ParentId":"765d6041baaa23390504094a101b8f4e3433e99a03cb0f5cf20e3b2e3a2a7523","RepoTags":["registry:latest"],"Size":0,"VirtualSize":411649320}
+        ,{"Created":1415863680,"Id":"765d6041baaa23390504094a101b8f4e3433e99a03cb0f5cf20e3b2e3a2a7523","ParentId":"c978e4c4261aec2dbc24c84427460afdaeaa64359ff4ed0ad6d4d00f0e0e0cd7","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649320}
+        ,{"Created":1415863680,"Id":"c978e4c4261aec2dbc24c84427460afdaeaa64359ff4ed0ad6d4d00f0e0e0cd7","ParentId":"f846b2ccf2c5679f8d95014285a8e771441b5e5fc04670e0dfcb1242e985eb5e","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649320}
+        ,{"Created":1415863679,"Id":"7949c9f83980aab0ac80e3150c0d3f899556c68f35d8f6f9ca7c79ecb769b70e","ParentId":"e8ca0e3bcd941b41c0c3dabebdb545f8331ddbb25257e6bc2cd3b6e6233d64f5","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":50796,"VirtualSize":411649320}
+        ,{"Created":1415863679,"Id":"f846b2ccf2c5679f8d95014285a8e771441b5e5fc04670e0dfcb1242e985eb5e","ParentId":"7949c9f83980aab0ac80e3150c0d3f899556c68f35d8f6f9ca7c79ecb769b70e","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649320}
+        ,{"Created":1415863677,"Id":"e8ca0e3bcd941b41c0c3dabebdb545f8331ddbb25257e6bc2cd3b6e6233d64f5","ParentId":"d242d0f728d9aaec3a24215bd3f6fc85a365f36bbb97727a84d5de7cc45792c4","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":23990121,"VirtualSize":411598524}
+        ,{"Created":1415863518,"Id":"d242d0f728d9aaec3a24215bd3f6fc85a365f36bbb97727a84d5de7cc45792c4","ParentId":"b3b586534b2a68b97cec6e3d676fe1b2a1713565929c7e9ff331aad04eaf83cb","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":11550557,"VirtualSize":387608403}
+        ,{"Created":1415863510,"Id":"b3b586534b2a68b97cec6e3d676fe1b2a1713565929c7e9ff331aad04eaf83cb","ParentId":"1ac06968b34e2b5b7c4e16488a4059f6493018f6744a57cf6a4fd2418f7acc4f","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":73,"VirtualSize":376057846}
+        ,{"Created":1415863509,"Id":"1ac06968b34e2b5b7c4e16488a4059f6493018f6744a57cf6a4fd2418f7acc4f","ParentId":"7d49ba12f2de52ae8dfec8c661f4471e00d546b57adc3913cefc56f89b932e22","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1879606,"VirtualSize":376057773}
+        ,{"Created":1415309161,"Id":"7d49ba12f2de52ae8dfec8c661f4471e00d546b57adc3913cefc56f89b932e22","ParentId":"5506de2b643be1e6febbf3b8a240760c6843244c41e12aa2f60ccbb7153d17f5","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":174920601,"VirtualSize":374178167}
+        ,{"Created":1415306638,"Id":"f6fab3b798be3174f45aa1eb731f8182705555f89c9026d8c1ef230cbf8301dd","ParentId":"f10807909bc552de261ca7463effc467600c3dca68d8e7704425283a6911d2ca","RepoTags":["debian:wheezy"],"Size":0,"VirtualSize":85100505}
+        ,{"Created":1415306636,"Id":"f10807909bc552de261ca7463effc467600c3dca68d8e7704425283a6911d2ca","ParentId":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":85100505,"VirtualSize":85100505}
+        ,{"Created":1414177799,"Id":"c723c9b95ac05c29c3e96b0b02e8fcf12096d850306b776a17877ee061daf49f","ParentId":"74dc9d28a649ac161e2a70d84190fe576f77f403f2565012f07bd68d638d291a","RepoTags":["registry:0.7.3"],"Size":0,"VirtualSize":426413472}
+        ,{"Created":1414177799,"Id":"74dc9d28a649ac161e2a70d84190fe576f77f403f2565012f07bd68d638d291a","ParentId":"00bcc0fe318f87107ed0db582ed109899506cd2cde230505ea11a5c400e9ac7a","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":426413472}
+        ,{"Created":1414177798,"Id":"00bcc0fe318f87107ed0db582ed109899506cd2cde230505ea11a5c400e9ac7a","ParentId":"96490e2b34642fabcdf6c4c157bd07be2caf4a71b9bd42c27386a1ff28d94d0c","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":426413472}
+        ,{"Created":1414177798,"Id":"96490e2b34642fabcdf6c4c157bd07be2caf4a71b9bd42c27386a1ff28d94d0c","ParentId":"1168ef7bd438745360d3506a6182ed73fec60bfea4181732dd75d6447016f012","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":426413472}
+        ,{"Created":1414177797,"Id":"1168ef7bd438745360d3506a6182ed73fec60bfea4181732dd75d6447016f012","ParentId":"a9c8dae074b96475a0775e199f79e456f0ee9a8288164e0b84fcc65ca163432e","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":20135062,"VirtualSize":426413472}
+        ,{"Created":1414177667,"Id":"a9c8dae074b96475a0775e199f79e456f0ee9a8288164e0b84fcc65ca163432e","ParentId":"17b869d7773564fa1ca26ef3aa5b3a9e615dabd1a433a4a00848c0c9790096fe","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":8437018,"VirtualSize":406278410}
+        ,{"Created":1414177663,"Id":"17b869d7773564fa1ca26ef3aa5b3a9e615dabd1a433a4a00848c0c9790096fe","ParentId":"4627c1e0f2389a25dce44361dba566542607509b4fec86cc7fae9f6bb93dc2eb","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":73,"VirtualSize":397841392}
+        ,{"Created":1414177663,"Id":"4627c1e0f2389a25dce44361dba566542607509b4fec86cc7fae9f6bb93dc2eb","ParentId":"6ffb25246d5531cdbf15ac250dcf0d10fca544944eaf7386b4cff8577488f258","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1657815,"VirtualSize":397841319}
+        ,{"Created":1414174623,"Id":"881f05ab63649f7d4b4ab048a2e01725c6a2d45f8866807bdb7766e28cdf224e","ParentId":"74583b71c35c28e06e11e0af0193351b852f3e9466a7b2c19a3add9a8528ee57","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":462038905}
+        ,{"Created":1414174623,"Id":"bee70978874ce288a546770e762196041c90d5b0c0ef7e0c3d2e551d79417701","ParentId":"881f05ab63649f7d4b4ab048a2e01725c6a2d45f8866807bdb7766e28cdf224e","RepoTags":["registry:0.6.9"],"Size":0,"VirtualSize":462038905}
+        ,{"Created":1414174623,"Id":"74583b71c35c28e06e11e0af0193351b852f3e9466a7b2c19a3add9a8528ee57","ParentId":"0909821a1551e63f5b169edaa3fa460134d86aa0ed5e6ed3acb4f50afa98002d","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":462038905}
+        ,{"Created":1414174622,"Id":"0909821a1551e63f5b169edaa3fa460134d86aa0ed5e6ed3acb4f50afa98002d","ParentId":"ad702f54c76e4d5e1fb47f9efc355c871f7087ae772ca0fafeedad8185d17058","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":34915187,"VirtualSize":462038905}
+        ,{"Created":1414174578,"Id":"29b16b1bfd162dd7b35cb98a72ad44108361bede4e42679e01dd8aa15aa1fe0f","ParentId":"f6d75c7fe58a905c14381100921562877d06a759acc70fbda6d3863796e0f003","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1613702,"VirtualSize":427123645}
+        ,{"Created":1414174578,"Id":"ad702f54c76e4d5e1fb47f9efc355c871f7087ae772ca0fafeedad8185d17058","ParentId":"29b16b1bfd162dd7b35cb98a72ad44108361bede4e42679e01dd8aa15aa1fe0f","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":73,"VirtualSize":427123718}
+        ,{"Created":1414126280,"Id":"6ffb25246d5531cdbf15ac250dcf0d10fca544944eaf7386b4cff8577488f258","ParentId":"9fe54074b35a3dd77eb2ffe2edf9226645e71fe292964b6d662a4010e695d9b8","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":41247201,"VirtualSize":396183504}
+        ,{"Created":1414126257,"Id":"9fe54074b35a3dd77eb2ffe2edf9226645e71fe292964b6d662a4010e695d9b8","ParentId":"cd72e4fcfd16a48d617cc8fe6c692400b55c3dd013a357f485a08a820f1f75ab","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":135294909,"VirtualSize":354936303}
+        ,{"Created":1414126216,"Id":"cd72e4fcfd16a48d617cc8fe6c692400b55c3dd013a357f485a08a820f1f75ab","ParentId":"57b5d5cb0bfe239f714f9a00439d7774f3b3359270f81ea74b41dbd7775eb46a","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":219641394}
+        ,{"Created":1414126211,"Id":"57b5d5cb0bfe239f714f9a00439d7774f3b3359270f81ea74b41dbd7775eb46a","ParentId":"5506de2b643be1e6febbf3b8a240760c6843244c41e12aa2f60ccbb7153d17f5","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":20383828,"VirtualSize":219641394}
+        ,{"Created":1414108439,"Id":"5506de2b643be1e6febbf3b8a240760c6843244c41e12aa2f60ccbb7153d17f5","ParentId":"22093c35d77bb609b9257ffb2640845ec05018e3d96cb939f68d0e19127f1723","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":199257566}
+        ,{"Created":1414108438,"Id":"22093c35d77bb609b9257ffb2640845ec05018e3d96cb939f68d0e19127f1723","ParentId":"3680052c0f5cf8ecb86ddf4d6ed331c89cdb691554572a80ec04724cf6ee9436","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":6557772,"VirtualSize":199257566}
+        ,{"Created":1414108414,"Id":"3680052c0f5cf8ecb86ddf4d6ed331c89cdb691554572a80ec04724cf6ee9436","ParentId":"e791be0477f28fd52f7609aed81733427d4cc0da620962d072e18ebcb32720a4","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1895,"VirtualSize":192699794}
+        ,{"Created":1414108413,"Id":"e791be0477f28fd52f7609aed81733427d4cc0da620962d072e18ebcb32720a4","ParentId":"ccb62158e97068cc05b2f0927a8acde14c64d0d363cc448238357fe221a39699","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":192697899}
+        ,{"Created":1414108412,"Id":"ccb62158e97068cc05b2f0927a8acde14c64d0d363cc448238357fe221a39699","ParentId":"d497ad3926c8997e1e0de74cdd5285489bb2c4acd6db15292e04bbab07047cd0","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":194791,"VirtualSize":192697899}
+        ,{"Created":1413872056,"Id":"d497ad3926c8997e1e0de74cdd5285489bb2c4acd6db15292e04bbab07047cd0","ParentId":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":192503108,"VirtualSize":192503108}
+        ,{"Created":1412204406,"Id":"f6d75c7fe58a905c14381100921562877d06a759acc70fbda6d3863796e0f003","ParentId":"b083996910428bc46e25ad7c7c0d5dd84c8ced88fe0cceeafe01787d9abd8848","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":6614587,"VirtualSize":425509943}
+        ,{"Created":1412204399,"Id":"b083996910428bc46e25ad7c7c0d5dd84c8ced88fe0cceeafe01787d9abd8848","ParentId":"c07f578f0911d8a712ae9e6909f8778fae749d0dabf65542aba8428c553388ac","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":10478,"VirtualSize":418895356}
+        ,{"Created":1412204376,"Id":"c07f578f0911d8a712ae9e6909f8778fae749d0dabf65542aba8428c553388ac","ParentId":"195eb90b534950d334188c3627f860fbdf898e224d8a0a11ec54ff453175e081","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":234168708,"VirtualSize":418884878}
+        ,{"Created":1412196370,"Id":"d415c60e5ea32875e4ddc7f7578bfaac3d59fb16e1334e705398b10ee91af801","ParentId":"0dfaa2625e19b0925a9e0fc7ea2c2a7f4fd0d31ec1e9838d08bf1310965ffc75","RepoTags":["busybox:ubuntu-12.04"],"Size":0,"VirtualSize":5454693}
+        ,{"Created":1412196370,"Id":"0dfaa2625e19b0925a9e0fc7ea2c2a7f4fd0d31ec1e9838d08bf1310965ffc75","ParentId":"df7546f9f060a2268024c8a230d8639878585defcc1bc6f79d2728a13957871b","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":5454693,"VirtualSize":5454693}
+        ,{"Created":1412196368,"Id":"e72ac664f4f0c6a061ac4ef332557a70d69b0c624b6add35f1c181ff7fff2287","ParentId":"e433a6c5b276a31aa38bf6eaba9cd1cfd69ea33f706ed72b3f20bafde5cd8644","RepoTags":["busybox:buildroot-2014.02","busybox:latest"],"Size":0,"VirtualSize":2433303}
+        ,{"Created":1412196368,"Id":"e433a6c5b276a31aa38bf6eaba9cd1cfd69ea33f706ed72b3f20bafde5cd8644","ParentId":"df7546f9f060a2268024c8a230d8639878585defcc1bc6f79d2728a13957871b","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":2433303,"VirtualSize":2433303}
+        ,{"Created":1412196367,"Id":"4b2909447dbef01f71ca476725c2dbb3af12de41aa2d7491d62c66678ede2294","ParentId":"ad8766e8635d2ae9ddd77d32b8f0fa091fb88fffed77b3a8a240bdcdc6f5aa05","RepoTags":["busybox:buildroot-2013.08.1"],"Size":0,"VirtualSize":2489301}
+        ,{"Created":1412196367,"Id":"df7546f9f060a2268024c8a230d8639878585defcc1bc6f79d2728a13957871b","ParentId":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":0}
+        ,{"Created":1412196367,"Id":"ad8766e8635d2ae9ddd77d32b8f0fa091fb88fffed77b3a8a240bdcdc6f5aa05","ParentId":"df7546f9f060a2268024c8a230d8639878585defcc1bc6f79d2728a13957871b","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":2489301,"VirtualSize":2489301}
+        ,{"Created":1403128415,"Id":"195eb90b534950d334188c3627f860fbdf898e224d8a0a11ec54ff453175e081","ParentId":"209ea56fda6dc2fb013e4d1e40cb678b2af91d1b54a71529f7df0bd867adc961","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":4411741,"VirtualSize":184716170}
+        ,{"Created":1403128408,"Id":"209ea56fda6dc2fb013e4d1e40cb678b2af91d1b54a71529f7df0bd867adc961","ParentId":"0f4aac48388f5d65a725ccf8e7caada42f136026c566528a5ee9b02467dac90a","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":74007417,"VirtualSize":180304429}
+        ,{"Created":1403128396,"Id":"0f4aac48388f5d65a725ccf8e7caada42f136026c566528a5ee9b02467dac90a","ParentId":"fae16849ebe23b48f2bedcc08aaabd45408c62b531ffd8d3088592043d5e7364","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1887,"VirtualSize":106297012}
+        ,{"Created":1403128396,"Id":"fae16849ebe23b48f2bedcc08aaabd45408c62b531ffd8d3088592043d5e7364","ParentId":"f127542f0b6191e99bb015b672f5cf48fa79d974784ac8090b11aeac184eaaff","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":189999,"VirtualSize":106295125}
+        ,{"Created":1403128393,"Id":"f127542f0b6191e99bb015b672f5cf48fa79d974784ac8090b11aeac184eaaff","ParentId":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":106105126,"VirtualSize":106105126}
+        ,{"Created":1371157430,"Id":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","ParentId":"","RepoTags":["scratch:latest"],"Size":0,"VirtualSize":0}
+        ]
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:44 GMT
+- request:
+    method: get
+    uri: "<DOCKER_HOST>/v1.15/images/b239f80471db/json"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Dec 2014 18:08:44 GMT
+      Content-Length:
+      - '1451'
+    body:
+      encoding: UTF-8
+      string: |
+        {"Architecture":"amd64","Author":"","Comment":"","Config":{"AttachStderr":false,"AttachStdin":false,"AttachStdout":false,"Cmd":["/true"],"CpuShares":0,"Cpuset":"","Domainname":"","Entrypoint":null,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","TRIVIAL=CHANGE"],"ExposedPorts":null,"Hostname":"0d1fedb580de","Image":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","Memory":0,"MemorySwap":0,"NetworkDisabled":false,"OnBuild":[],"OpenStdin":false,"PortSpecs":null,"SecurityOpt":null,"StdinOnce":false,"Tty":false,"User":"","Volumes":null,"WorkingDir":""},"Container":"6d0c01400c38e0783f2be9f22d9ef47c1e8b56fa83085d4d7ea360e94916640f","ContainerConfig":{"AttachStderr":false,"AttachStdin":false,"AttachStdout":false,"Cmd":["/bin/sh","-c","#(nop) ENV TRIVIAL=CHANGE"],"CpuShares":0,"Cpuset":"","Domainname":"","Entrypoint":null,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","TRIVIAL=CHANGE"],"ExposedPorts":null,"Hostname":"0d1fedb580de","Image":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","Memory":0,"MemorySwap":0,"NetworkDisabled":false,"OnBuild":[],"OpenStdin":false,"PortSpecs":null,"SecurityOpt":null,"StdinOnce":false,"Tty":false,"User":"","Volumes":null,"WorkingDir":""},"Created":"2014-12-10T02:32:41.527606628Z","DockerVersion":"1.3.1","Id":"b239f80471dbc0ee17ca34e648e4cc0b1013c740bccb621d6ad00edbc3f26dc7","Os":"linux","Parent":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","Size":0,"VirtualSize":125}
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:44 GMT
+- request:
+    method: post
+    uri: "<DOCKER_HOST>/v1.15/images/<USERNAME>/true/push?tag=latest"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - text/plain
+      X-Registry-Auth:
+      - eyJ1c2VybmFtZSI6InRkdWZmaWVsZCIsInBhc3N3b3JkIjoiaTlCZj5KZ3ZmYmpZL3NKV01jVTkiLCJzZXJ2ZXJhZGRyZXNzIjoiaHR0cHM6Ly9pbmRleC5kb2NrZXIuaW8vdjEiLCJlbWFpbCI6ImdpdGh1YkB0b21kdWZmaWVsZC5jb20ifQ==
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Dec 2014 18:08:44 GMT
+    body:
+      encoding: UTF-8
+      string: "{\"status\":\"The push refers to a repository [<USERNAME>/true] (len:
+        1)\"}\r\n{\"status\":\"Sending image list\"}\r\n{\"errorDetail\":{\"message\":\"Error:
+        Status 401 trying to push repository <USERNAME>/true: \\\"\\\"\"},\"error\":\"Error:
+        Status 401 trying to push repository <USERNAME>/true: \\\"\\\"\"}\r\n"
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:45 GMT
+- request:
+    method: delete
+    uri: "<DOCKER_HOST>/v1.15/images/<USERNAME>/true?noprune=true"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Dec 2014 18:08:45 GMT
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: |-
+        [{"Untagged":"<USERNAME>/true:latest"}
+        ]
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:45 GMT
+recorded_with: VCR 2.9.3

--- a/spec/vcr/Docker_Image/_push/when_a_tag_is_specified/pushes_that_specific_tag.yml
+++ b/spec/vcr/Docker_Image/_push/when_a_tag_is_specified/pushes_that_specific_tag.yml
@@ -1,0 +1,332 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<DOCKER_HOST>/v1.15/build?t=<USERNAME>%2Ftrue"
+    body:
+      encoding: UTF-8
+      string: !binary |-
+        RG9ja2VyZmlsZQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAADAwMDA2NDAAMDAwMDAwMAAwMDAwMDAwADAwMDAwMDAwMDIx
+        ADEyNDM3MTI3MjU0ADAxMzMwNAAgMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB1c3RhcgAwMHdoZWVs
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAd2hlZWwAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAwMDAwMDAwADAwMDAwMDAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAABGUk9NIHRpYW5vbi90cnVlCgAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Dec 2014 18:08:44 GMT
+    body:
+      encoding: UTF-8
+      string: "{\"stream\":\"Step 0 : FROM tianon/true\\n\"}\r\n{\"stream\":\" ---\\u003e
+        69e7aca3d78e\\n\"}\r\n{\"stream\":\"Step 1 : ENV TRIVIAL CHANGE\\n\"}\r\n{\"stream\":\"
+        ---\\u003e Running in 6d0c01400c38\\n\"}\r\n{\"stream\":\" ---\\u003e b239f80471db\\n\"}\r\n{\"stream\":\"Removing
+        intermediate container 6d0c01400c38\\n\"}\r\n{\"stream\":\"Successfully built
+        b239f80471db\\n\"}\r\n"
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:44 GMT
+- request:
+    method: get
+    uri: "<DOCKER_HOST>/v1.15/images/json?all=true"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Dec 2014 18:08:44 GMT
+    body:
+      encoding: UTF-8
+      string: |-
+        [{"Created":1418178761,"Id":"b239f80471dbc0ee17ca34e648e4cc0b1013c740bccb621d6ad00edbc3f26dc7","ParentId":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","RepoTags":["<USERNAME>/true:latest"],"Size":0,"VirtualSize":125}
+        ,{"Created":1417805428,"Id":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","ParentId":"9d182a4ffb01e4ecfc5397bf9a989016e7ae6920f6e64a037db4c0a2f3c0e264","RepoTags":["tianon/true:latest"],"Size":0,"VirtualSize":125}
+        ,{"Created":1416799251,"Id":"0b7a3c1fbea815d721ccf5404d05e0d8c667945ebe21acdf530fae3aa22184ce","ParentId":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":125,"VirtualSize":125}
+        ,{"Created":1415864019,"Id":"74f5b38a45c97043cdf0082b8e8dd002497ab6b03388cdb2f20bafb7468ad55b","ParentId":"31ae66be94f160a92e1e757ab9a66aa7183af55183080576fb93a52cbce9e0cd","RepoTags":["registry:0.9.0"],"Size":0,"VirtualSize":411649756}
+        ,{"Created":1415864018,"Id":"31ae66be94f160a92e1e757ab9a66aa7183af55183080576fb93a52cbce9e0cd","ParentId":"b3fd13d94685095ec1c1f8f0f371dde8be9a21f8f457d4d10e5ad72042a152af","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649756}
+        ,{"Created":1415864017,"Id":"eae8be82bb623181222558e4df0dd59c943cdc2fd3c4e41de669e4bd35a866e6","ParentId":"8eae38b276496440046cd9f545c24533e692cbed6fd1bc4e29a7af5e4ae72a61","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649756}
+        ,{"Created":1415864017,"Id":"b3fd13d94685095ec1c1f8f0f371dde8be9a21f8f457d4d10e5ad72042a152af","ParentId":"eae8be82bb623181222558e4df0dd59c943cdc2fd3c4e41de669e4bd35a866e6","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649756}
+        ,{"Created":1415864016,"Id":"8eae38b276496440046cd9f545c24533e692cbed6fd1bc4e29a7af5e4ae72a61","ParentId":"16b02bf8dc3d1f70e098cbd968f154468fcf41be6bf59b24a35b4fdded3edbca","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":50796,"VirtualSize":411649756}
+        ,{"Created":1415864015,"Id":"16b02bf8dc3d1f70e098cbd968f154468fcf41be6bf59b24a35b4fdded3edbca","ParentId":"b22cb7ed5ccbeeaf2a67d5d3034a308c6eedf2ccb247851c9a14c05b441716fa","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":23990121,"VirtualSize":411598960}
+        ,{"Created":1415863862,"Id":"b22cb7ed5ccbeeaf2a67d5d3034a308c6eedf2ccb247851c9a14c05b441716fa","ParentId":"8b170afd480f41a84331dcaabfa6465769205e645ba13f8baa085f1f68e4f1cf","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":11550557,"VirtualSize":387608839}
+        ,{"Created":1415863855,"Id":"8b170afd480f41a84331dcaabfa6465769205e645ba13f8baa085f1f68e4f1cf","ParentId":"8dda8bb23254979ce24f2ca4d7115f4563a9ae4f0e774b2d419318d81a5c720d","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":73,"VirtualSize":376058282}
+        ,{"Created":1415863853,"Id":"8dda8bb23254979ce24f2ca4d7115f4563a9ae4f0e774b2d419318d81a5c720d","ParentId":"7d49ba12f2de52ae8dfec8c661f4471e00d546b57adc3913cefc56f89b932e22","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1880042,"VirtualSize":376058209}
+        ,{"Created":1415863849,"Id":"d9925ba888d4dba2d9b22273d261155fe3b2a4e6cfa5db44e4abe5ac8e311efa","ParentId":"4abfff610473315c2fb7a6278c924948ba877fe6630ad197f734572b7636188e","RepoTags":["registry:0.8.1"],"Size":0,"VirtualSize":430388853}
+        ,{"Created":1415863848,"Id":"4abfff610473315c2fb7a6278c924948ba877fe6630ad197f734572b7636188e","ParentId":"8b840022b4b5d60e0f66d7f72b992eb5b52e75dfdf1b8e9535d85df57236e7f5","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":430388853}
+        ,{"Created":1415863847,"Id":"8b840022b4b5d60e0f66d7f72b992eb5b52e75dfdf1b8e9535d85df57236e7f5","ParentId":"11d3a913c69b0ea1c7d0df3708dfa8c789b68dc0884471cf862de1160c7eaaba","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":430388853}
+        ,{"Created":1415863846,"Id":"11d3a913c69b0ea1c7d0df3708dfa8c789b68dc0884471cf862de1160c7eaaba","ParentId":"ae88728b911af97e928890b1c3b7b34dd25fb313f3b20cd73e532e2903d3d3b9","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":430388853}
+        ,{"Created":1415863845,"Id":"ae88728b911af97e928890b1c3b7b34dd25fb313f3b20cd73e532e2903d3d3b9","ParentId":"16c101215b54ac2210fa62d54e0893323ae43e3d33b75119b1246a9dbbc1c7cf","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":23901352,"VirtualSize":430388853}
+        ,{"Created":1415863690,"Id":"16c101215b54ac2210fa62d54e0893323ae43e3d33b75119b1246a9dbbc1c7cf","ParentId":"4c86ccffaf465d6688815f844bfadbb91a76df42043e629d208c5b75de31b891","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":8442747,"VirtualSize":406487501}
+        ,{"Created":1415863686,"Id":"4c86ccffaf465d6688815f844bfadbb91a76df42043e629d208c5b75de31b891","ParentId":"e930198c27c4d790fd3eece5212c7ab1e6f272bfd21061c877b38696aa91ac27","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":73,"VirtualSize":398044754}
+        ,{"Created":1415863685,"Id":"e930198c27c4d790fd3eece5212c7ab1e6f272bfd21061c877b38696aa91ac27","ParentId":"6ffb25246d5531cdbf15ac250dcf0d10fca544944eaf7386b4cff8577488f258","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1861177,"VirtualSize":398044681}
+        ,{"Created":1415863681,"Id":"7e2db37c6564bf030e6c5af9725bf9f9a8196846e3a77a51e201fc97871e2e60","ParentId":"765d6041baaa23390504094a101b8f4e3433e99a03cb0f5cf20e3b2e3a2a7523","RepoTags":["registry:latest"],"Size":0,"VirtualSize":411649320}
+        ,{"Created":1415863680,"Id":"765d6041baaa23390504094a101b8f4e3433e99a03cb0f5cf20e3b2e3a2a7523","ParentId":"c978e4c4261aec2dbc24c84427460afdaeaa64359ff4ed0ad6d4d00f0e0e0cd7","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649320}
+        ,{"Created":1415863680,"Id":"c978e4c4261aec2dbc24c84427460afdaeaa64359ff4ed0ad6d4d00f0e0e0cd7","ParentId":"f846b2ccf2c5679f8d95014285a8e771441b5e5fc04670e0dfcb1242e985eb5e","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649320}
+        ,{"Created":1415863679,"Id":"7949c9f83980aab0ac80e3150c0d3f899556c68f35d8f6f9ca7c79ecb769b70e","ParentId":"e8ca0e3bcd941b41c0c3dabebdb545f8331ddbb25257e6bc2cd3b6e6233d64f5","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":50796,"VirtualSize":411649320}
+        ,{"Created":1415863679,"Id":"f846b2ccf2c5679f8d95014285a8e771441b5e5fc04670e0dfcb1242e985eb5e","ParentId":"7949c9f83980aab0ac80e3150c0d3f899556c68f35d8f6f9ca7c79ecb769b70e","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649320}
+        ,{"Created":1415863677,"Id":"e8ca0e3bcd941b41c0c3dabebdb545f8331ddbb25257e6bc2cd3b6e6233d64f5","ParentId":"d242d0f728d9aaec3a24215bd3f6fc85a365f36bbb97727a84d5de7cc45792c4","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":23990121,"VirtualSize":411598524}
+        ,{"Created":1415863518,"Id":"d242d0f728d9aaec3a24215bd3f6fc85a365f36bbb97727a84d5de7cc45792c4","ParentId":"b3b586534b2a68b97cec6e3d676fe1b2a1713565929c7e9ff331aad04eaf83cb","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":11550557,"VirtualSize":387608403}
+        ,{"Created":1415863510,"Id":"b3b586534b2a68b97cec6e3d676fe1b2a1713565929c7e9ff331aad04eaf83cb","ParentId":"1ac06968b34e2b5b7c4e16488a4059f6493018f6744a57cf6a4fd2418f7acc4f","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":73,"VirtualSize":376057846}
+        ,{"Created":1415863509,"Id":"1ac06968b34e2b5b7c4e16488a4059f6493018f6744a57cf6a4fd2418f7acc4f","ParentId":"7d49ba12f2de52ae8dfec8c661f4471e00d546b57adc3913cefc56f89b932e22","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1879606,"VirtualSize":376057773}
+        ,{"Created":1415309161,"Id":"7d49ba12f2de52ae8dfec8c661f4471e00d546b57adc3913cefc56f89b932e22","ParentId":"5506de2b643be1e6febbf3b8a240760c6843244c41e12aa2f60ccbb7153d17f5","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":174920601,"VirtualSize":374178167}
+        ,{"Created":1415306638,"Id":"f6fab3b798be3174f45aa1eb731f8182705555f89c9026d8c1ef230cbf8301dd","ParentId":"f10807909bc552de261ca7463effc467600c3dca68d8e7704425283a6911d2ca","RepoTags":["debian:wheezy"],"Size":0,"VirtualSize":85100505}
+        ,{"Created":1415306636,"Id":"f10807909bc552de261ca7463effc467600c3dca68d8e7704425283a6911d2ca","ParentId":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":85100505,"VirtualSize":85100505}
+        ,{"Created":1414177799,"Id":"c723c9b95ac05c29c3e96b0b02e8fcf12096d850306b776a17877ee061daf49f","ParentId":"74dc9d28a649ac161e2a70d84190fe576f77f403f2565012f07bd68d638d291a","RepoTags":["registry:0.7.3"],"Size":0,"VirtualSize":426413472}
+        ,{"Created":1414177799,"Id":"74dc9d28a649ac161e2a70d84190fe576f77f403f2565012f07bd68d638d291a","ParentId":"00bcc0fe318f87107ed0db582ed109899506cd2cde230505ea11a5c400e9ac7a","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":426413472}
+        ,{"Created":1414177798,"Id":"00bcc0fe318f87107ed0db582ed109899506cd2cde230505ea11a5c400e9ac7a","ParentId":"96490e2b34642fabcdf6c4c157bd07be2caf4a71b9bd42c27386a1ff28d94d0c","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":426413472}
+        ,{"Created":1414177798,"Id":"96490e2b34642fabcdf6c4c157bd07be2caf4a71b9bd42c27386a1ff28d94d0c","ParentId":"1168ef7bd438745360d3506a6182ed73fec60bfea4181732dd75d6447016f012","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":426413472}
+        ,{"Created":1414177797,"Id":"1168ef7bd438745360d3506a6182ed73fec60bfea4181732dd75d6447016f012","ParentId":"a9c8dae074b96475a0775e199f79e456f0ee9a8288164e0b84fcc65ca163432e","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":20135062,"VirtualSize":426413472}
+        ,{"Created":1414177667,"Id":"a9c8dae074b96475a0775e199f79e456f0ee9a8288164e0b84fcc65ca163432e","ParentId":"17b869d7773564fa1ca26ef3aa5b3a9e615dabd1a433a4a00848c0c9790096fe","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":8437018,"VirtualSize":406278410}
+        ,{"Created":1414177663,"Id":"17b869d7773564fa1ca26ef3aa5b3a9e615dabd1a433a4a00848c0c9790096fe","ParentId":"4627c1e0f2389a25dce44361dba566542607509b4fec86cc7fae9f6bb93dc2eb","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":73,"VirtualSize":397841392}
+        ,{"Created":1414177663,"Id":"4627c1e0f2389a25dce44361dba566542607509b4fec86cc7fae9f6bb93dc2eb","ParentId":"6ffb25246d5531cdbf15ac250dcf0d10fca544944eaf7386b4cff8577488f258","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1657815,"VirtualSize":397841319}
+        ,{"Created":1414174623,"Id":"881f05ab63649f7d4b4ab048a2e01725c6a2d45f8866807bdb7766e28cdf224e","ParentId":"74583b71c35c28e06e11e0af0193351b852f3e9466a7b2c19a3add9a8528ee57","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":462038905}
+        ,{"Created":1414174623,"Id":"bee70978874ce288a546770e762196041c90d5b0c0ef7e0c3d2e551d79417701","ParentId":"881f05ab63649f7d4b4ab048a2e01725c6a2d45f8866807bdb7766e28cdf224e","RepoTags":["registry:0.6.9"],"Size":0,"VirtualSize":462038905}
+        ,{"Created":1414174623,"Id":"74583b71c35c28e06e11e0af0193351b852f3e9466a7b2c19a3add9a8528ee57","ParentId":"0909821a1551e63f5b169edaa3fa460134d86aa0ed5e6ed3acb4f50afa98002d","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":462038905}
+        ,{"Created":1414174622,"Id":"0909821a1551e63f5b169edaa3fa460134d86aa0ed5e6ed3acb4f50afa98002d","ParentId":"ad702f54c76e4d5e1fb47f9efc355c871f7087ae772ca0fafeedad8185d17058","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":34915187,"VirtualSize":462038905}
+        ,{"Created":1414174578,"Id":"29b16b1bfd162dd7b35cb98a72ad44108361bede4e42679e01dd8aa15aa1fe0f","ParentId":"f6d75c7fe58a905c14381100921562877d06a759acc70fbda6d3863796e0f003","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1613702,"VirtualSize":427123645}
+        ,{"Created":1414174578,"Id":"ad702f54c76e4d5e1fb47f9efc355c871f7087ae772ca0fafeedad8185d17058","ParentId":"29b16b1bfd162dd7b35cb98a72ad44108361bede4e42679e01dd8aa15aa1fe0f","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":73,"VirtualSize":427123718}
+        ,{"Created":1414126280,"Id":"6ffb25246d5531cdbf15ac250dcf0d10fca544944eaf7386b4cff8577488f258","ParentId":"9fe54074b35a3dd77eb2ffe2edf9226645e71fe292964b6d662a4010e695d9b8","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":41247201,"VirtualSize":396183504}
+        ,{"Created":1414126257,"Id":"9fe54074b35a3dd77eb2ffe2edf9226645e71fe292964b6d662a4010e695d9b8","ParentId":"cd72e4fcfd16a48d617cc8fe6c692400b55c3dd013a357f485a08a820f1f75ab","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":135294909,"VirtualSize":354936303}
+        ,{"Created":1414126216,"Id":"cd72e4fcfd16a48d617cc8fe6c692400b55c3dd013a357f485a08a820f1f75ab","ParentId":"57b5d5cb0bfe239f714f9a00439d7774f3b3359270f81ea74b41dbd7775eb46a","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":219641394}
+        ,{"Created":1414126211,"Id":"57b5d5cb0bfe239f714f9a00439d7774f3b3359270f81ea74b41dbd7775eb46a","ParentId":"5506de2b643be1e6febbf3b8a240760c6843244c41e12aa2f60ccbb7153d17f5","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":20383828,"VirtualSize":219641394}
+        ,{"Created":1414108439,"Id":"5506de2b643be1e6febbf3b8a240760c6843244c41e12aa2f60ccbb7153d17f5","ParentId":"22093c35d77bb609b9257ffb2640845ec05018e3d96cb939f68d0e19127f1723","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":199257566}
+        ,{"Created":1414108438,"Id":"22093c35d77bb609b9257ffb2640845ec05018e3d96cb939f68d0e19127f1723","ParentId":"3680052c0f5cf8ecb86ddf4d6ed331c89cdb691554572a80ec04724cf6ee9436","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":6557772,"VirtualSize":199257566}
+        ,{"Created":1414108414,"Id":"3680052c0f5cf8ecb86ddf4d6ed331c89cdb691554572a80ec04724cf6ee9436","ParentId":"e791be0477f28fd52f7609aed81733427d4cc0da620962d072e18ebcb32720a4","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1895,"VirtualSize":192699794}
+        ,{"Created":1414108413,"Id":"e791be0477f28fd52f7609aed81733427d4cc0da620962d072e18ebcb32720a4","ParentId":"ccb62158e97068cc05b2f0927a8acde14c64d0d363cc448238357fe221a39699","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":192697899}
+        ,{"Created":1414108412,"Id":"ccb62158e97068cc05b2f0927a8acde14c64d0d363cc448238357fe221a39699","ParentId":"d497ad3926c8997e1e0de74cdd5285489bb2c4acd6db15292e04bbab07047cd0","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":194791,"VirtualSize":192697899}
+        ,{"Created":1413872056,"Id":"d497ad3926c8997e1e0de74cdd5285489bb2c4acd6db15292e04bbab07047cd0","ParentId":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":192503108,"VirtualSize":192503108}
+        ,{"Created":1412204406,"Id":"f6d75c7fe58a905c14381100921562877d06a759acc70fbda6d3863796e0f003","ParentId":"b083996910428bc46e25ad7c7c0d5dd84c8ced88fe0cceeafe01787d9abd8848","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":6614587,"VirtualSize":425509943}
+        ,{"Created":1412204399,"Id":"b083996910428bc46e25ad7c7c0d5dd84c8ced88fe0cceeafe01787d9abd8848","ParentId":"c07f578f0911d8a712ae9e6909f8778fae749d0dabf65542aba8428c553388ac","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":10478,"VirtualSize":418895356}
+        ,{"Created":1412204376,"Id":"c07f578f0911d8a712ae9e6909f8778fae749d0dabf65542aba8428c553388ac","ParentId":"195eb90b534950d334188c3627f860fbdf898e224d8a0a11ec54ff453175e081","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":234168708,"VirtualSize":418884878}
+        ,{"Created":1412196370,"Id":"d415c60e5ea32875e4ddc7f7578bfaac3d59fb16e1334e705398b10ee91af801","ParentId":"0dfaa2625e19b0925a9e0fc7ea2c2a7f4fd0d31ec1e9838d08bf1310965ffc75","RepoTags":["busybox:ubuntu-12.04"],"Size":0,"VirtualSize":5454693}
+        ,{"Created":1412196370,"Id":"0dfaa2625e19b0925a9e0fc7ea2c2a7f4fd0d31ec1e9838d08bf1310965ffc75","ParentId":"df7546f9f060a2268024c8a230d8639878585defcc1bc6f79d2728a13957871b","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":5454693,"VirtualSize":5454693}
+        ,{"Created":1412196368,"Id":"e72ac664f4f0c6a061ac4ef332557a70d69b0c624b6add35f1c181ff7fff2287","ParentId":"e433a6c5b276a31aa38bf6eaba9cd1cfd69ea33f706ed72b3f20bafde5cd8644","RepoTags":["busybox:buildroot-2014.02","busybox:latest"],"Size":0,"VirtualSize":2433303}
+        ,{"Created":1412196368,"Id":"e433a6c5b276a31aa38bf6eaba9cd1cfd69ea33f706ed72b3f20bafde5cd8644","ParentId":"df7546f9f060a2268024c8a230d8639878585defcc1bc6f79d2728a13957871b","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":2433303,"VirtualSize":2433303}
+        ,{"Created":1412196367,"Id":"4b2909447dbef01f71ca476725c2dbb3af12de41aa2d7491d62c66678ede2294","ParentId":"ad8766e8635d2ae9ddd77d32b8f0fa091fb88fffed77b3a8a240bdcdc6f5aa05","RepoTags":["busybox:buildroot-2013.08.1"],"Size":0,"VirtualSize":2489301}
+        ,{"Created":1412196367,"Id":"df7546f9f060a2268024c8a230d8639878585defcc1bc6f79d2728a13957871b","ParentId":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":0}
+        ,{"Created":1412196367,"Id":"ad8766e8635d2ae9ddd77d32b8f0fa091fb88fffed77b3a8a240bdcdc6f5aa05","ParentId":"df7546f9f060a2268024c8a230d8639878585defcc1bc6f79d2728a13957871b","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":2489301,"VirtualSize":2489301}
+        ,{"Created":1403128415,"Id":"195eb90b534950d334188c3627f860fbdf898e224d8a0a11ec54ff453175e081","ParentId":"209ea56fda6dc2fb013e4d1e40cb678b2af91d1b54a71529f7df0bd867adc961","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":4411741,"VirtualSize":184716170}
+        ,{"Created":1403128408,"Id":"209ea56fda6dc2fb013e4d1e40cb678b2af91d1b54a71529f7df0bd867adc961","ParentId":"0f4aac48388f5d65a725ccf8e7caada42f136026c566528a5ee9b02467dac90a","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":74007417,"VirtualSize":180304429}
+        ,{"Created":1403128396,"Id":"0f4aac48388f5d65a725ccf8e7caada42f136026c566528a5ee9b02467dac90a","ParentId":"fae16849ebe23b48f2bedcc08aaabd45408c62b531ffd8d3088592043d5e7364","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":1887,"VirtualSize":106297012}
+        ,{"Created":1403128396,"Id":"fae16849ebe23b48f2bedcc08aaabd45408c62b531ffd8d3088592043d5e7364","ParentId":"f127542f0b6191e99bb015b672f5cf48fa79d974784ac8090b11aeac184eaaff","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":189999,"VirtualSize":106295125}
+        ,{"Created":1403128393,"Id":"f127542f0b6191e99bb015b672f5cf48fa79d974784ac8090b11aeac184eaaff","ParentId":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":106105126,"VirtualSize":106105126}
+        ,{"Created":1371157430,"Id":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","ParentId":"","RepoTags":["scratch:latest"],"Size":0,"VirtualSize":0}
+        ]
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:44 GMT
+- request:
+    method: get
+    uri: "<DOCKER_HOST>/v1.15/images/b239f80471db/json"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Dec 2014 18:08:44 GMT
+      Content-Length:
+      - '1451'
+    body:
+      encoding: UTF-8
+      string: |
+        {"Architecture":"amd64","Author":"","Comment":"","Config":{"AttachStderr":false,"AttachStdin":false,"AttachStdout":false,"Cmd":["/true"],"CpuShares":0,"Cpuset":"","Domainname":"","Entrypoint":null,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","TRIVIAL=CHANGE"],"ExposedPorts":null,"Hostname":"0d1fedb580de","Image":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","Memory":0,"MemorySwap":0,"NetworkDisabled":false,"OnBuild":[],"OpenStdin":false,"PortSpecs":null,"SecurityOpt":null,"StdinOnce":false,"Tty":false,"User":"","Volumes":null,"WorkingDir":""},"Container":"6d0c01400c38e0783f2be9f22d9ef47c1e8b56fa83085d4d7ea360e94916640f","ContainerConfig":{"AttachStderr":false,"AttachStdin":false,"AttachStdout":false,"Cmd":["/bin/sh","-c","#(nop) ENV TRIVIAL=CHANGE"],"CpuShares":0,"Cpuset":"","Domainname":"","Entrypoint":null,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","TRIVIAL=CHANGE"],"ExposedPorts":null,"Hostname":"0d1fedb580de","Image":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","Memory":0,"MemorySwap":0,"NetworkDisabled":false,"OnBuild":[],"OpenStdin":false,"PortSpecs":null,"SecurityOpt":null,"StdinOnce":false,"Tty":false,"User":"","Volumes":null,"WorkingDir":""},"Created":"2014-12-10T02:32:41.527606628Z","DockerVersion":"1.3.1","Id":"b239f80471dbc0ee17ca34e648e4cc0b1013c740bccb621d6ad00edbc3f26dc7","Os":"linux","Parent":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","Size":0,"VirtualSize":125}
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:44 GMT
+- request:
+    method: post
+    uri: "<DOCKER_HOST>/v1.15/images/b239f80471db/tag?repo=<USERNAME>%2Ftrue&tag=also"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 201
+      message: 
+    headers:
+      Date:
+      - Mon, 01 Dec 2014 18:08:44 GMT
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/plain; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:44 GMT
+- request:
+    method: post
+    uri: "<DOCKER_HOST>/v1.15/images/<USERNAME>/true/push?tag=also"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - text/plain
+      X-Registry-Auth:
+      - eyJ1c2VybmFtZSI6InRkdWZmaWVsZCIsInBhc3N3b3JkIjoiaTlCZj5KZ3ZmYmpZL3NKV01jVTkiLCJzZXJ2ZXJhZGRyZXNzIjoiaHR0cHM6Ly9pbmRleC5kb2NrZXIuaW8vdjEiLCJlbWFpbCI6ImdpdGh1YkB0b21kdWZmaWVsZC5jb20ifQ==
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Dec 2014 18:08:44 GMT
+    body:
+      encoding: UTF-8
+      string: "{\"status\":\"The push refers to a repository [<USERNAME>/true] (len:
+        1)\"}\r\n{\"status\":\"Sending image list\"}\r\n{\"status\":\"Pushing repository
+        <USERNAME>/true (1 tags)\"}\r\n{\"status\":\"Pushing\",\"progressDetail\":{},\"id\":\"511136ea3c5a\"}{\"status\":\"Image
+        already pushed, skipping\",\"progressDetail\":{},\"id\":\"511136ea3c5a\"}{\"status\":\"Pushing\",\"progressDetail\":{},\"id\":\"9d182a4ffb01\"}{\"status\":\"Image
+        already pushed, skipping\",\"progressDetail\":{},\"id\":\"9d182a4ffb01\"}{\"status\":\"Pushing\",\"progressDetail\":{},\"id\":\"69e7aca3d78e\"}{\"status\":\"Image
+        already pushed, skipping\",\"progressDetail\":{},\"id\":\"69e7aca3d78e\"}{\"status\":\"Pushing\",\"progressDetail\":{},\"id\":\"b239f80471db\"}{\"status\":\"Buffering
+        to disk\",\"progressDetail\":{\"current\":3072,\"start\":1418178781},\"progress\":\"3.072
+        kB\",\"id\":\"b239f80471db\"}{\"status\":\"Buffering to disk\",\"progressDetail\":{\"start\":1418178781},\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":512,\"total\":3072,\"start\":1418178781},\"progress\":\"[========\\u003e
+        \                                         ]    512 B/3.072 kB 3s\",\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":1024,\"total\":3072,\"start\":1418178781},\"progress\":\"[================\\u003e
+        \                                 ] 1.024 kB/3.072 kB 1s\",\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":1536,\"total\":3072,\"start\":1418178781},\"progress\":\"[=========================\\u003e
+        \                        ] 1.536 kB/3.072 kB 0\",\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":2048,\"total\":3072,\"start\":1418178781},\"progress\":\"[=================================\\u003e
+        \                ] 2.048 kB/3.072 kB 0\",\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":2560,\"total\":3072,\"start\":1418178781},\"progress\":\"[=========================================\\u003e
+        \        ]  2.56 kB/3.072 kB 0\",\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":3072,\"total\":3072,\"start\":1418178781},\"progress\":\"[==================================================\\u003e]
+        3.072 kB/3.072 kB\",\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":3072,\"total\":3072,\"start\":1418178781},\"progress\":\"[==================================================\\u003e]
+        3.072 kB/3.072 kB\",\"id\":\"b239f80471db\"}{\"status\":\"Image successfully
+        pushed\",\"progressDetail\":{},\"id\":\"b239f80471db\"}{\"status\":\"Pushing
+        tag for rev [b239f80471db] on {https://cdn-registry-1.docker.io/v1/repositories/<USERNAME>/true/tags/also}\"}\r\n"
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:45 GMT
+- request:
+    method: delete
+    uri: "<DOCKER_HOST>/v1.15/images/<USERNAME>/true:also?noprune=true"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Dec 2014 18:08:45 GMT
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: |-
+        [{"Untagged":"<USERNAME>/true:latest"}
+        ]
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:45 GMT
+- request:
+    method: delete
+    uri: "<DOCKER_HOST>/v1.15/images/<USERNAME>/true?noprune=true"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.15.0
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Dec 2014 18:08:45 GMT
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: |-
+        [{"Untagged":"<USERNAME>/true:latest"}
+        ]
+    http_version: 
+  recorded_at: Mon, 01 Dec 2014 18:08:45 GMT
+recorded_with: VCR 2.9.3

--- a/spec/vcr/Docker_Image/_push/when_the_image_was_retrived_by_get/when_no_tag_is_specified/looks_up_the_first_repo_tag.yml
+++ b/spec/vcr/Docker_Image/_push/when_the_image_was_retrived_by_get/when_no_tag_is_specified/looks_up_the_first_repo_tag.yml
@@ -69,7 +69,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "{\"stream\":\"Step 0 : FROM tianon/true\\n\"}\r\n{\"stream\":\" ---\\u003e
-        65972374029e\\n\"}\r\n{\"stream\":\"Successfully built 65972374029e\\n\"}\r\n"
+        69e7aca3d78e\\n\"}\r\n{\"stream\":\"Step 1 : ENV TRIVIAL CHANGE\\n\"}\r\n{\"stream\":\"
+        ---\\u003e Running in 6d0c01400c38\\n\"}\r\n{\"stream\":\" ---\\u003e b239f80471db\\n\"}\r\n{\"stream\":\"Removing
+        intermediate container 6d0c01400c38\\n\"}\r\n{\"stream\":\"Successfully built
+        b239f80471db\\n\"}\r\n"
     http_version: 
   recorded_at: Thu, 04 Dec 2014 23:17:37 GMT
 - request:
@@ -95,8 +98,8 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |-
-        [{"Created":1417635468,"Id":"c154f223aa51a9427329e873f6a615e5716f7b0927b73cc0d5db3b04f14f2ce0","ParentId":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":125,"VirtualSize":125}
-        ,{"Created":1417635468,"Id":"65972374029e7324127a3e211c4fca4cdd8d6d1b09393f33eaebe23e5d649527","ParentId":"c154f223aa51a9427329e873f6a615e5716f7b0927b73cc0d5db3b04f14f2ce0","RepoTags":["<USERNAME>/true:latest","tianon/true:latest"],"Size":0,"VirtualSize":125}
+        [{"Created":1418178761,"Id":"b239f80471dbc0ee17ca34e648e4cc0b1013c740bccb621d6ad00edbc3f26dc7","ParentId":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","RepoTags":["<USERNAME>/true:latest"],"Size":0,"VirtualSize":125}
+        ,{"Created":1417805428,"Id":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","ParentId":"9d182a4ffb01e4ecfc5397bf9a989016e7ae6920f6e64a037db4c0a2f3c0e264","RepoTags":["tianon/true:latest"],"Size":0,"VirtualSize":125}
         ,{"Created":1417622693,"Id":"6d369ae9ddef62aebe8fbd5e0c3a2b5be6096f46e62953e4787ebd6f0d249dbb","ParentId":"fe8d782094431737f45fc5a66feb2cad153cd80fdb4057a578969764b0d2411d","RepoTags":["hackuman/behavioral:production","hackuman/behavioral:staging"],"Size":0,"VirtualSize":1291998921}
         ,{"Created":1417622693,"Id":"fe8d782094431737f45fc5a66feb2cad153cd80fdb4057a578969764b0d2411d","ParentId":"f3b2ba97d94de9e6596084b21e245dd17703192aae4771fc6ed23066a905c442","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":1291998921}
         ,{"Created":1417622691,"Id":"f3b2ba97d94de9e6596084b21e245dd17703192aae4771fc6ed23066a905c442","ParentId":"3be84a04f4219f73bb66ed38313b4399a3829058bbb141587cdd55cf58968b15","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":106548697,"VirtualSize":1291998921}
@@ -421,7 +424,7 @@ http_interactions:
   recorded_at: Thu, 04 Dec 2014 23:17:38 GMT
 - request:
     method: get
-    uri: "<DOCKER_HOST>/v1.15/images/65972374029e/json"
+    uri: "<DOCKER_HOST>/v1.15/images/b239f80471db/json"
     body:
       encoding: US-ASCII
       string: ''
@@ -444,7 +447,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {"Architecture":"amd64","Author":"","Comment":"","Config":{"AttachStderr":false,"AttachStdin":false,"AttachStdout":false,"Cmd":["/true"],"CpuShares":0,"Cpuset":"","Domainname":"","Entrypoint":null,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],"ExposedPorts":null,"Hostname":"4efcd4e42b1a","Image":"c154f223aa51a9427329e873f6a615e5716f7b0927b73cc0d5db3b04f14f2ce0","Memory":0,"MemorySwap":0,"NetworkDisabled":false,"OnBuild":[],"OpenStdin":false,"PortSpecs":null,"SecurityOpt":null,"StdinOnce":false,"Tty":false,"User":"","Volumes":null,"WorkingDir":""},"Container":"b8377c5c623a0b0ac853ac8f17ba9afe1044cbae5c6e2167b545967c399a2891","ContainerConfig":{"AttachStderr":false,"AttachStdin":false,"AttachStdout":false,"Cmd":["/bin/sh","-c","#(nop) CMD [/true]"],"CpuShares":0,"Cpuset":"","Domainname":"","Entrypoint":null,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],"ExposedPorts":null,"Hostname":"4efcd4e42b1a","Image":"c154f223aa51a9427329e873f6a615e5716f7b0927b73cc0d5db3b04f14f2ce0","Memory":0,"MemorySwap":0,"NetworkDisabled":false,"OnBuild":[],"OpenStdin":false,"PortSpecs":null,"SecurityOpt":null,"StdinOnce":false,"Tty":false,"User":"","Volumes":null,"WorkingDir":""},"Created":"2014-12-03T19:37:48.147386075Z","DockerVersion":"1.3.2","Id":"65972374029e7324127a3e211c4fca4cdd8d6d1b09393f33eaebe23e5d649527","Os":"linux","Parent":"c154f223aa51a9427329e873f6a615e5716f7b0927b73cc0d5db3b04f14f2ce0","Size":0,"VirtualSize":125}
+        {"Architecture":"amd64","Author":"","Comment":"","Config":{"AttachStderr":false,"AttachStdin":false,"AttachStdout":false,"Cmd":["/true"],"CpuShares":0,"Cpuset":"","Domainname":"","Entrypoint":null,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","TRIVIAL=CHANGE"],"ExposedPorts":null,"Hostname":"0d1fedb580de","Image":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","Memory":0,"MemorySwap":0,"NetworkDisabled":false,"OnBuild":[],"OpenStdin":false,"PortSpecs":null,"SecurityOpt":null,"StdinOnce":false,"Tty":false,"User":"","Volumes":null,"WorkingDir":""},"Container":"6d0c01400c38e0783f2be9f22d9ef47c1e8b56fa83085d4d7ea360e94916640f","ContainerConfig":{"AttachStderr":false,"AttachStdin":false,"AttachStdout":false,"Cmd":["/bin/sh","-c","#(nop) ENV TRIVIAL=CHANGE"],"CpuShares":0,"Cpuset":"","Domainname":"","Entrypoint":null,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","TRIVIAL=CHANGE"],"ExposedPorts":null,"Hostname":"0d1fedb580de","Image":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","Memory":0,"MemorySwap":0,"NetworkDisabled":false,"OnBuild":[],"OpenStdin":false,"PortSpecs":null,"SecurityOpt":null,"StdinOnce":false,"Tty":false,"User":"","Volumes":null,"WorkingDir":""},"Created":"2014-12-10T02:32:41.527606628Z","DockerVersion":"1.3.1","Id":"b239f80471dbc0ee17ca34e648e4cc0b1013c740bccb621d6ad00edbc3f26dc7","Os":"linux","Parent":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","Size":0,"VirtualSize":125}
     http_version: 
   recorded_at: Thu, 04 Dec 2014 23:17:38 GMT
 - request:
@@ -472,7 +475,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {"Architecture":"amd64","Author":"","Comment":"","Config":{"AttachStderr":false,"AttachStdin":false,"AttachStdout":false,"Cmd":["/true"],"CpuShares":0,"Cpuset":"","Domainname":"","Entrypoint":null,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],"ExposedPorts":null,"Hostname":"4efcd4e42b1a","Image":"c154f223aa51a9427329e873f6a615e5716f7b0927b73cc0d5db3b04f14f2ce0","Memory":0,"MemorySwap":0,"NetworkDisabled":false,"OnBuild":[],"OpenStdin":false,"PortSpecs":null,"SecurityOpt":null,"StdinOnce":false,"Tty":false,"User":"","Volumes":null,"WorkingDir":""},"Container":"b8377c5c623a0b0ac853ac8f17ba9afe1044cbae5c6e2167b545967c399a2891","ContainerConfig":{"AttachStderr":false,"AttachStdin":false,"AttachStdout":false,"Cmd":["/bin/sh","-c","#(nop) CMD [/true]"],"CpuShares":0,"Cpuset":"","Domainname":"","Entrypoint":null,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],"ExposedPorts":null,"Hostname":"4efcd4e42b1a","Image":"c154f223aa51a9427329e873f6a615e5716f7b0927b73cc0d5db3b04f14f2ce0","Memory":0,"MemorySwap":0,"NetworkDisabled":false,"OnBuild":[],"OpenStdin":false,"PortSpecs":null,"SecurityOpt":null,"StdinOnce":false,"Tty":false,"User":"","Volumes":null,"WorkingDir":""},"Created":"2014-12-03T19:37:48.147386075Z","DockerVersion":"1.3.2","Id":"65972374029e7324127a3e211c4fca4cdd8d6d1b09393f33eaebe23e5d649527","Os":"linux","Parent":"c154f223aa51a9427329e873f6a615e5716f7b0927b73cc0d5db3b04f14f2ce0","Size":0,"VirtualSize":125}
+        {"Architecture":"amd64","Author":"","Comment":"","Config":{"AttachStderr":false,"AttachStdin":false,"AttachStdout":false,"Cmd":["/true"],"CpuShares":0,"Cpuset":"","Domainname":"","Entrypoint":null,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","TRIVIAL=CHANGE"],"ExposedPorts":null,"Hostname":"0d1fedb580de","Image":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","Memory":0,"MemorySwap":0,"NetworkDisabled":false,"OnBuild":[],"OpenStdin":false,"PortSpecs":null,"SecurityOpt":null,"StdinOnce":false,"Tty":false,"User":"","Volumes":null,"WorkingDir":""},"Container":"6d0c01400c38e0783f2be9f22d9ef47c1e8b56fa83085d4d7ea360e94916640f","ContainerConfig":{"AttachStderr":false,"AttachStdin":false,"AttachStdout":false,"Cmd":["/bin/sh","-c","#(nop) ENV TRIVIAL=CHANGE"],"CpuShares":0,"Cpuset":"","Domainname":"","Entrypoint":null,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","TRIVIAL=CHANGE"],"ExposedPorts":null,"Hostname":"0d1fedb580de","Image":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","Memory":0,"MemorySwap":0,"NetworkDisabled":false,"OnBuild":[],"OpenStdin":false,"PortSpecs":null,"SecurityOpt":null,"StdinOnce":false,"Tty":false,"User":"","Volumes":null,"WorkingDir":""},"Created":"2014-12-10T02:32:41.527606628Z","DockerVersion":"1.3.1","Id":"b239f80471dbc0ee17ca34e648e4cc0b1013c740bccb621d6ad00edbc3f26dc7","Os":"linux","Parent":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","Size":0,"VirtualSize":125}
     http_version: 
   recorded_at: Thu, 04 Dec 2014 23:17:38 GMT
 - request:
@@ -498,8 +501,8 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |-
-        [{"Created":1417635468,"Id":"65972374029e7324127a3e211c4fca4cdd8d6d1b09393f33eaebe23e5d649527","ParentId":"c154f223aa51a9427329e873f6a615e5716f7b0927b73cc0d5db3b04f14f2ce0","RepoTags":["<USERNAME>/true:latest","tianon/true:latest"],"Size":0,"VirtualSize":125}
-        ,{"Created":1417635468,"Id":"c154f223aa51a9427329e873f6a615e5716f7b0927b73cc0d5db3b04f14f2ce0","ParentId":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":125,"VirtualSize":125}
+        [{"Created":1418178761,"Id":"b239f80471dbc0ee17ca34e648e4cc0b1013c740bccb621d6ad00edbc3f26dc7","ParentId":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","RepoTags":["<USERNAME>/true:latest"],"Size":0,"VirtualSize":125}
+        ,{"Created":1417805428,"Id":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","ParentId":"9d182a4ffb01e4ecfc5397bf9a989016e7ae6920f6e64a037db4c0a2f3c0e264","RepoTags":["tianon/true:latest"],"Size":0,"VirtualSize":125}
         ,{"Created":1417622693,"Id":"6d369ae9ddef62aebe8fbd5e0c3a2b5be6096f46e62953e4787ebd6f0d249dbb","ParentId":"fe8d782094431737f45fc5a66feb2cad153cd80fdb4057a578969764b0d2411d","RepoTags":["hackuman/behavioral:staging","hackuman/behavioral:production"],"Size":0,"VirtualSize":1291998921}
         ,{"Created":1417622693,"Id":"fe8d782094431737f45fc5a66feb2cad153cd80fdb4057a578969764b0d2411d","ParentId":"f3b2ba97d94de9e6596084b21e245dd17703192aae4771fc6ed23066a905c442","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":1291998921}
         ,{"Created":1417622691,"Id":"f3b2ba97d94de9e6596084b21e245dd17703192aae4771fc6ed23066a905c442","ParentId":"3be84a04f4219f73bb66ed38313b4399a3829058bbb141587cdd55cf58968b15","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":106548697,"VirtualSize":1291998921}
@@ -824,7 +827,7 @@ http_interactions:
   recorded_at: Thu, 04 Dec 2014 23:17:39 GMT
 - request:
     method: get
-    uri: "<DOCKER_HOST>/v1.15/images/65972374029e7324127a3e211c4fca4cdd8d6d1b09393f33eaebe23e5d649527/json"
+    uri: "<DOCKER_HOST>/v1.15/images/b239f80471dbc0ee17ca34e648e4cc0b1013c740bccb621d6ad00edbc3f26dc7/json"
     body:
       encoding: US-ASCII
       string: ''
@@ -875,13 +878,22 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "{\"status\":\"The push refers to a repository [<USERNAME>/true] (len:
-        1)\"}\r\n{\"status\":\"Sending image list\"}\r\n{\"errorDetail\":{\"message\":\"Error:
-        Status 404 trying to push repository <USERNAME>/true: {\\\"status_code\\\":
-        \\\"404\\\", \\\"error\\\": \\\"The requested URL (/v1/repositories/<USERNAME>/true/)
-        was not found on this server.\\\"}\"},\"error\":\"Error: Status 404 trying
-        to push repository <USERNAME>/true: {\\\"status_code\\\": \\\"404\\\", \\\"error\\\":
-        \\\"The requested URL (/v1/repositories/<USERNAME>/true/) was not found on
-        this server.\\\"}\"}\r\n"
+        1)\"}\r\n{\"status\":\"Sending image list\"}\r\n{\"status\":\"Pushing repository
+        <USERNAME>/true (1 tags)\"}\r\n{\"status\":\"Pushing\",\"progressDetail\":{},\"id\":\"511136ea3c5a\"}{\"status\":\"Image
+        already pushed, skipping\",\"progressDetail\":{},\"id\":\"511136ea3c5a\"}{\"status\":\"Pushing\",\"progressDetail\":{},\"id\":\"9d182a4ffb01\"}{\"status\":\"Image
+        already pushed, skipping\",\"progressDetail\":{},\"id\":\"9d182a4ffb01\"}{\"status\":\"Pushing\",\"progressDetail\":{},\"id\":\"69e7aca3d78e\"}{\"status\":\"Image
+        already pushed, skipping\",\"progressDetail\":{},\"id\":\"69e7aca3d78e\"}{\"status\":\"Pushing\",\"progressDetail\":{},\"id\":\"b239f80471db\"}{\"status\":\"Buffering
+        to disk\",\"progressDetail\":{\"current\":3072,\"start\":1418178781},\"progress\":\"3.072
+        kB\",\"id\":\"b239f80471db\"}{\"status\":\"Buffering to disk\",\"progressDetail\":{\"start\":1418178781},\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":512,\"total\":3072,\"start\":1418178781},\"progress\":\"[========\\u003e
+        \                                         ]    512 B/3.072 kB 3s\",\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":1024,\"total\":3072,\"start\":1418178781},\"progress\":\"[================\\u003e
+        \                                 ] 1.024 kB/3.072 kB 1s\",\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":1536,\"total\":3072,\"start\":1418178781},\"progress\":\"[=========================\\u003e
+        \                        ] 1.536 kB/3.072 kB 0\",\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":2048,\"total\":3072,\"start\":1418178781},\"progress\":\"[=================================\\u003e
+        \                ] 2.048 kB/3.072 kB 0\",\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":2560,\"total\":3072,\"start\":1418178781},\"progress\":\"[=========================================\\u003e
+        \        ]  2.56 kB/3.072 kB 0\",\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":3072,\"total\":3072,\"start\":1418178781},\"progress\":\"[==================================================\\u003e]
+        3.072 kB/3.072 kB\",\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":3072,\"total\":3072,\"start\":1418178781},\"progress\":\"[==================================================\\u003e]
+        3.072 kB/3.072 kB\",\"id\":\"b239f80471db\"}{\"status\":\"Image successfully
+        pushed\",\"progressDetail\":{},\"id\":\"b239f80471db\"}{\"status\":\"Pushing
+        tag for rev [b239f80471db] on {https://cdn-registry-1.docker.io/v1/repositories/<USERNAME>/true/tags/latest}\"}\r\n"
     http_version: 
   recorded_at: Thu, 04 Dec 2014 23:17:40 GMT
 - request:

--- a/spec/vcr/Docker_Image/_push/when_there_are_no_credentials/still_pushes.yml
+++ b/spec/vcr/Docker_Image/_push/when_there_are_no_credentials/still_pushes.yml
@@ -69,7 +69,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "{\"stream\":\"Step 0 : FROM tianon/true\\n\"}\r\n{\"stream\":\" ---\\u003e
-        08e20b347507\\n\"}\r\n{\"stream\":\"Successfully built 08e20b347507\\n\"}\r\n"
+        69e7aca3d78e\\n\"}\r\n{\"stream\":\"Step 1 : ENV TRIVIAL CHANGE\\n\"}\r\n{\"stream\":\"
+        ---\\u003e Running in 6d0c01400c38\\n\"}\r\n{\"stream\":\" ---\\u003e b239f80471db\\n\"}\r\n{\"stream\":\"Removing
+        intermediate container 6d0c01400c38\\n\"}\r\n{\"stream\":\"Successfully built
+        b239f80471db\\n\"}\r\n"
     http_version: 
   recorded_at: Mon, 01 Dec 2014 18:08:45 GMT
 - request:
@@ -95,8 +98,8 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |-
-        [{"Created":1416799251,"Id":"0b7a3c1fbea815d721ccf5404d05e0d8c667945ebe21acdf530fae3aa22184ce","ParentId":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":125,"VirtualSize":125}
-        ,{"Created":1416799251,"Id":"08e20b3475072326a5f6855b4bca4fe53680d025f379eb54c5076de119cae17b","ParentId":"0b7a3c1fbea815d721ccf5404d05e0d8c667945ebe21acdf530fae3aa22184ce","RepoTags":["tianon/true:latest","localhost:5000/true:latest"],"Size":0,"VirtualSize":125}
+        [{"Created":1418178761,"Id":"b239f80471dbc0ee17ca34e648e4cc0b1013c740bccb621d6ad00edbc3f26dc7","ParentId":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","RepoTags":["localhost:5000/true:latest"],"Size":0,"VirtualSize":125}
+        ,{"Created":1417805428,"Id":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","ParentId":"9d182a4ffb01e4ecfc5397bf9a989016e7ae6920f6e64a037db4c0a2f3c0e264","RepoTags":["tianon/true:latest"],"Size":0,"VirtualSize":125}
         ,{"Created":1415864019,"Id":"74f5b38a45c97043cdf0082b8e8dd002497ab6b03388cdb2f20bafb7468ad55b","ParentId":"31ae66be94f160a92e1e757ab9a66aa7183af55183080576fb93a52cbce9e0cd","RepoTags":["registry:0.9.0"],"Size":0,"VirtualSize":411649756}
         ,{"Created":1415864018,"Id":"31ae66be94f160a92e1e757ab9a66aa7183af55183080576fb93a52cbce9e0cd","ParentId":"b3fd13d94685095ec1c1f8f0f371dde8be9a21f8f457d4d10e5ad72042a152af","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649756}
         ,{"Created":1415864017,"Id":"b3fd13d94685095ec1c1f8f0f371dde8be9a21f8f457d4d10e5ad72042a152af","ParentId":"eae8be82bb623181222558e4df0dd59c943cdc2fd3c4e41de669e4bd35a866e6","RepoTags":["\u003cnone\u003e:\u003cnone\u003e"],"Size":0,"VirtualSize":411649756}
@@ -171,7 +174,7 @@ http_interactions:
   recorded_at: Mon, 01 Dec 2014 18:08:45 GMT
 - request:
     method: get
-    uri: "<DOCKER_HOST>/v1.15/images/08e20b347507/json"
+    uri: "<DOCKER_HOST>/v1.15/images/b239f80471db/json"
     body:
       encoding: US-ASCII
       string: ''
@@ -194,12 +197,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        {"Architecture":"amd64","Author":"","Comment":"","Config":{"AttachStderr":false,"AttachStdin":false,"AttachStdout":false,"Cmd":["/true"],"CpuShares":0,"Cpuset":"","Domainname":"","Entrypoint":null,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],"ExposedPorts":null,"Hostname":"cb7d701676d5","Image":"0b7a3c1fbea815d721ccf5404d05e0d8c667945ebe21acdf530fae3aa22184ce","Memory":0,"MemorySwap":0,"NetworkDisabled":false,"OnBuild":[],"OpenStdin":false,"PortSpecs":null,"StdinOnce":false,"Tty":false,"User":"","Volumes":null,"WorkingDir":""},"Container":"c21f74268c73d08aee59691b5b4b5771ca49cdc73dee76a3778cc214801da20e","ContainerConfig":{"AttachStderr":false,"AttachStdin":false,"AttachStdout":false,"Cmd":["/bin/sh","-c","#(nop) CMD [/true]"],"CpuShares":0,"Cpuset":"","Domainname":"","Entrypoint":null,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],"ExposedPorts":null,"Hostname":"cb7d701676d5","Image":"0b7a3c1fbea815d721ccf5404d05e0d8c667945ebe21acdf530fae3aa22184ce","Memory":0,"MemorySwap":0,"NetworkDisabled":false,"OnBuild":[],"OpenStdin":false,"PortSpecs":null,"StdinOnce":false,"Tty":false,"User":"","Volumes":null,"WorkingDir":""},"Created":"2014-11-24T03:20:51.740435043Z","DockerVersion":"1.3.2","Id":"08e20b3475072326a5f6855b4bca4fe53680d025f379eb54c5076de119cae17b","Os":"linux","Parent":"0b7a3c1fbea815d721ccf5404d05e0d8c667945ebe21acdf530fae3aa22184ce","Size":0,"VirtualSize":125}
+        {"Architecture":"amd64","Author":"","Comment":"","Config":{"AttachStderr":false,"AttachStdin":false,"AttachStdout":false,"Cmd":["/true"],"CpuShares":0,"Cpuset":"","Domainname":"","Entrypoint":null,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","TRIVIAL=CHANGE"],"ExposedPorts":null,"Hostname":"0d1fedb580de","Image":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","Memory":0,"MemorySwap":0,"NetworkDisabled":false,"OnBuild":[],"OpenStdin":false,"PortSpecs":null,"SecurityOpt":null,"StdinOnce":false,"Tty":false,"User":"","Volumes":null,"WorkingDir":""},"Container":"6d0c01400c38e0783f2be9f22d9ef47c1e8b56fa83085d4d7ea360e94916640f","ContainerConfig":{"AttachStderr":false,"AttachStdin":false,"AttachStdout":false,"Cmd":["/bin/sh","-c","#(nop) ENV TRIVIAL=CHANGE"],"CpuShares":0,"Cpuset":"","Domainname":"","Entrypoint":null,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","TRIVIAL=CHANGE"],"ExposedPorts":null,"Hostname":"0d1fedb580de","Image":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","Memory":0,"MemorySwap":0,"NetworkDisabled":false,"OnBuild":[],"OpenStdin":false,"PortSpecs":null,"SecurityOpt":null,"StdinOnce":false,"Tty":false,"User":"","Volumes":null,"WorkingDir":""},"Created":"2014-12-10T02:32:41.527606628Z","DockerVersion":"1.3.1","Id":"b239f80471dbc0ee17ca34e648e4cc0b1013c740bccb621d6ad00edbc3f26dc7","Os":"linux","Parent":"69e7aca3d78e5c15557cb19a905bb432207d7f0e433ec592c60bb3b5aabffe85","Size":0,"VirtualSize":125}
     http_version: 
   recorded_at: Mon, 01 Dec 2014 18:08:45 GMT
 - request:
     method: post
-    uri: "<DOCKER_HOST>/v1.15/images/tianon/true/push?tag=latest"
+    uri: "<DOCKER_HOST>/v1.15/images/localhost:5000/true/push?tag=latest"
     body:
       encoding: US-ASCII
       string: ''
@@ -221,10 +224,23 @@ http_interactions:
       - Mon, 01 Dec 2014 18:08:45 GMT
     body:
       encoding: UTF-8
-      string: "{\"status\":\"The push refers to a repository [tianon/true] (len: 1)\"}\r\n{\"status\":\"Sending
-        image list\"}\r\n{\"errorDetail\":{\"message\":\"Error: Status 401 trying
-        to push repository tianon/true: \\\"\\\"\"},\"error\":\"Error: Status 401
-        trying to push repository tianon/true: \\\"\\\"\"}\r\n"
+      string: "{\"status\":\"The push refers to a repository [localhost:5000/true] (len:
+        1)\"}\r\n{\"status\":\"Sending image list\"}\r\n{\"status\":\"Pushing repository
+        localhost:5000/true (1 tags)\"}\r\n{\"status\":\"Pushing\",\"progressDetail\":{},\"id\":\"511136ea3c5a\"}{\"status\":\"Image
+        already pushed, skipping\",\"progressDetail\":{},\"id\":\"511136ea3c5a\"}{\"status\":\"Pushing\",\"progressDetail\":{},\"id\":\"9d182a4ffb01\"}{\"status\":\"Image
+        already pushed, skipping\",\"progressDetail\":{},\"id\":\"9d182a4ffb01\"}{\"status\":\"Pushing\",\"progressDetail\":{},\"id\":\"69e7aca3d78e\"}{\"status\":\"Image
+        already pushed, skipping\",\"progressDetail\":{},\"id\":\"69e7aca3d78e\"}{\"status\":\"Pushing\",\"progressDetail\":{},\"id\":\"b239f80471db\"}{\"status\":\"Buffering
+        to disk\",\"progressDetail\":{\"current\":3072,\"start\":1418178781},\"progress\":\"3.072
+        kB\",\"id\":\"b239f80471db\"}{\"status\":\"Buffering to disk\",\"progressDetail\":{\"start\":1418178781},\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":512,\"total\":3072,\"start\":1418178781},\"progress\":\"[========\\u003e
+        \                                         ]    512 B/3.072 kB 3s\",\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":1024,\"total\":3072,\"start\":1418178781},\"progress\":\"[================\\u003e
+        \                                 ] 1.024 kB/3.072 kB 1s\",\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":1536,\"total\":3072,\"start\":1418178781},\"progress\":\"[=========================\\u003e
+        \                        ] 1.536 kB/3.072 kB 0\",\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":2048,\"total\":3072,\"start\":1418178781},\"progress\":\"[=================================\\u003e
+        \                ] 2.048 kB/3.072 kB 0\",\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":2560,\"total\":3072,\"start\":1418178781},\"progress\":\"[=========================================\\u003e
+        \        ]  2.56 kB/3.072 kB 0\",\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":3072,\"total\":3072,\"start\":1418178781},\"progress\":\"[==================================================\\u003e]
+        3.072 kB/3.072 kB\",\"id\":\"b239f80471db\"}{\"status\":\"Pushing\",\"progressDetail\":{\"current\":3072,\"total\":3072,\"start\":1418178781},\"progress\":\"[==================================================\\u003e]
+        3.072 kB/3.072 kB\",\"id\":\"b239f80471db\"}{\"status\":\"Image successfully
+        pushed\",\"progressDetail\":{},\"id\":\"b239f80471db\"}{\"status\":\"Pushing
+        tag for rev [b239f80471db] on {https://localhost:5000/true/tags/latest}\"}\r\n"
     http_version: 
   recorded_at: Mon, 01 Dec 2014 18:08:45 GMT
 - request:


### PR DESCRIPTION
This patch lets me show feedback during the long slow process of pushing or pulling an image.

* A block supplied to `Image#push` or `Image.create` will be called with the parsed hash of each json message streamed back from the server.
* create and push now raise errors if an error response is returned from the server
* The VCR example for creating an image was actually that of a 401 Unauthorized request. I faked data from a successful pull into the 'pushes_the_Image.yml' VCR record, and used the old version as the test case for an unauthorized call.

I'm not quite sure how I should be handling exceptions in all this. 

First, I'm assuming it's fair to raise an exception if any response from the server shows an error -- but if there are known-harmless errors out there, they will now be explodey.

Also, if an error condition occurs in the response_block, it is caught and re-thrown as an Excon error. So I'm throwing a generic error inside the block, then catching all excon errors and re-throwing only the ones I recognize (Unauthorized for push, Not Found for pull) as Docker errors. Let me know if you prefer some other strategy.

This obviates the PR in #209, as the last ID is retrieved naturally in the response block