### PR TITLE
Default argument for the `authenticate!` method references itself

### DIFF
--- a/lib/docker.rb
+++ b/lib/docker.rb
@@ -100,7 +100,7 @@ module Docker
   end
 
   # Login to the Docker registry.
-  def authenticate!(options = {}, connection = connection)
+  def authenticate!(options = {}, connection = self.connection)
     creds = options.to_json
     connection.post('/auth', {}, :body => creds)
     @creds = creds


### PR DESCRIPTION
This warning shows up now when using ruby 2.2.0.
