### PR TITLE
Remove circular argument reference

### DIFF
--- a/lib/docker.rb
+++ b/lib/docker.rb
@@ -100,7 +100,7 @@ module Docker
   end
 
   # Login to the Docker registry.
-  def authenticate!(options = {}, connection = connection)
+  def authenticate!(options = {}, connection = self.connection)
     creds = options.to_json
     connection.post('/auth', {}, :body => creds)
     @creds = creds


### PR DESCRIPTION
This changeset removes Ruby 2.2.0 warnings similar to this one:

```
bundle/ruby/2.2.0/gems/docker-api-1.17.0/lib/docker.rb:103: warning: circular argument reference - connection
```
