### PR TITLE
Calling `close_write` on io if necessary

### DIFF
--- a/lib/docker/util.rb
+++ b/lib/docker/util.rb
@@ -61,7 +61,12 @@ module Docker::Util
         IO.copy_stream stdin, socket
 
         debug "hijack: closing write end of hijacked socket"
-        socket.close_write
+        closable = if socket.respond_to?(:close_write)
+          socket
+        elsif socket.respond_to?(:io)
+          socket.io
+        end
+        closable.close_write
       end
 
       debug "hijack: starting hijacked socket read thread"


### PR DESCRIPTION
I was hitting the same problem as @myers in #214. [OpenSSL::SSLSocket](http://ruby-doc.org/stdlib-2.1.5/libdoc/openssl/rdoc/OpenSSL/SSL/SSLSocket.html) does not have a `close_write` method, but the `io` that it holds might. This seems to fix the problem for me locally.