### PR TITLE
Image create captures output

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -44,10 +44,8 @@ namespace :vcr do
       )
       registry.start
       Rake::Task["spec"].invoke
-    rescue
-      # nothing
     ensure
-      registry.kill!.remove
+      registry.kill!.remove unless registry.nil?
     end
   end
 end

--- a/docker-api.gemspec
+++ b/docker-api.gemspec
@@ -25,4 +25,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'vcr', '>= 2.7.0'
   gem.add_development_dependency 'simplecov'
   gem.add_development_dependency 'webmock'
+  # > 1.3.3 doesn't support ruby 1.9.2
+  gem.add_development_dependency 'parallel', '1.3.3'
 end

--- a/docker-api.gemspec
+++ b/docker-api.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'vcr', '>= 2.7.0'
   gem.add_development_dependency 'simplecov'
   gem.add_development_dependency 'webmock'
-  # > 1.3.3 doesn't support ruby 1.9.2
+  # > 1.3.4 doesn't support ruby 1.9.2
   gem.add_development_dependency 'parallel', '1.3.3'
 end

--- a/lib/docker/image.rb
+++ b/lib/docker/image.rb
@@ -104,8 +104,7 @@ class Docker::Image
     # Create a new Image.
     def create(opts = {}, creds = nil, conn = Docker.connection, &block)
       credentials = creds.nil? ? Docker.creds : creds.to_json
-      headers = !credentials.nil? && Docker::Util.build_auth_header(credentials)
-      headers ||= {}
+      headers = credentials && Docker::Util.build_auth_header(credentials) || {}
       body = ''
       conn.post(
         '/images/create',

--- a/lib/docker/image.rb
+++ b/lib/docker/image.rb
@@ -102,11 +102,17 @@ class Docker::Image
   class << self
 
     # Create a new Image.
-    def create(opts = {}, creds = nil, conn = Docker.connection)
+    def create(opts = {}, creds = nil, conn = Docker.connection, &block)
       credentials = creds.nil? ? Docker.creds : creds.to_json
       headers = !credentials.nil? && Docker::Util.build_auth_header(credentials)
       headers ||= {}
-      body = conn.post('/images/create', opts, :headers => headers)
+      body = ''
+      conn.post(
+        '/images/create',
+        opts,
+        :headers => headers,
+        :response_block => response_block(body, &block)
+      )
       json = Docker::Util.fix_json(body)
       image = json.reverse_each.find { |el| el && el.key?('id') }
       new(conn, 'id' => image && image.fetch('id'), :headers => headers)

--- a/spec/docker/image_spec.rb
+++ b/spec/docker/image_spec.rb
@@ -322,13 +322,12 @@ describe Docker::Image do
     context 'with a block capturing create output' do
       let(:create_output) { "" }
       let(:block) { Proc.new { |chunk| create_output << chunk } }
-      let!(:image) { subject.create('fromImage' => 'hawknewton/true', &block) }
+      let!(:image) { subject.create('fromImage' => 'tianon/true', &block) }
 
       before { Docker.creds = nil }
-      after { image.remove(:name => 'hawknewton/true', :noprune => true) }
 
       it 'calls the block and passes build output', :vcr do
-        expect(create_output).to match(/Pulling repository hawknewton\/true/)
+        expect(create_output).to match(/Pulling repository tianon\/true/)
       end
     end
   end

--- a/spec/docker/image_spec.rb
+++ b/spec/docker/image_spec.rb
@@ -318,6 +318,19 @@ describe Docker::Image do
         expect(image.info[:headers].keys).to include 'X-Registry-Auth'
       end
     end
+
+    context 'with a block capturing create output' do
+      let(:create_output) { "" }
+      let(:block) { Proc.new { |chunk| create_output << chunk } }
+      let!(:image) { subject.create('fromImage' => 'hawknewton/true', &block) }
+
+      before { Docker.creds = nil }
+      after { image.remove(:name => 'hawknewton/true', :noprune => true) }
+
+      it 'calls the block and passes build output', :vcr do
+        expect(create_output).to match(/Pulling repository hawknewton\/true/)
+      end
+    end
   end
 
   describe '.get' do

--- a/spec/vcr/Docker_Image/_create/with_a_block_capturing_create_output/calls_the_block_and_passes_build_output.yml
+++ b/spec/vcr/Docker_Image/_create/with_a_block_capturing_create_output/calls_the_block_and_passes_build_output.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: "<DOCKER_HOST>/v1.15/images/create?fromImage=hawknewton%2Ftrue"
+    uri: "<DOCKER_HOST>/v1.15/images/create?fromImage=tianon%2Ftrue"
     body:
       encoding: US-ASCII
       string: ''
@@ -19,47 +19,18 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 10 Jan 2015 13:52:23 GMT
+      - Wed, 11 Feb 2015 18:06:15 GMT
     body:
       encoding: UTF-8
-      string: "{\"status\":\"Pulling repository hawknewton/true\"}\r\n{\"status\":\"Pulling
-        image (latest) from hawknewton/true\",\"progressDetail\":{},\"id\":\"5fbce35eb337\"}{\"status\":\"Pulling
-        image (latest) from hawknewton/true, endpoint: https://registry-1.docker.io/v1/\",\"progressDetail\":{},\"id\":\"5fbce35eb337\"}{\"status\":\"Pulling
-        dependent layers\",\"progressDetail\":{},\"id\":\"5fbce35eb337\"}{\"status\":\"Download
+      string: "{\"status\":\"Pulling repository tianon/true\"}\r\n{\"status\":\"Pulling
+        image (latest) from tianon/true\",\"progressDetail\":{},\"id\":\"a47c4817ef07\"}{\"status\":\"Pulling
+        image (latest) from tianon/true, endpoint: https://registry-1.docker.io/v1/\",\"progressDetail\":{},\"id\":\"a47c4817ef07\"}{\"status\":\"Pulling
+        dependent layers\",\"progressDetail\":{},\"id\":\"a47c4817ef07\"}{\"status\":\"Download
         complete\",\"progressDetail\":{},\"id\":\"511136ea3c5a\"}{\"status\":\"Download
-        complete\",\"progressDetail\":{},\"id\":\"c0d559283422\"}{\"status\":\"Download
-        complete\",\"progressDetail\":{},\"id\":\"5fbce35eb337\"}{\"status\":\"Download
-        complete\",\"progressDetail\":{},\"id\":\"5fbce35eb337\"}{\"status\":\"Status:
-        Image is up to date for hawknewton/true\"}\r\n"
+        complete\",\"progressDetail\":{},\"id\":\"e41eb64a720e\"}{\"status\":\"Download
+        complete\",\"progressDetail\":{},\"id\":\"a47c4817ef07\"}{\"status\":\"Download
+        complete\",\"progressDetail\":{},\"id\":\"a47c4817ef07\"}{\"status\":\"Status:
+        Image is up to date for tianon/true\"}\r\n"
     http_version: 
-  recorded_at: Mon, 12 Jan 2015 22:21:11 GMT
-- request:
-    method: delete
-    uri: "<DOCKER_HOST>/v1.15/images/hawknewton/true?noprune=true"
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Swipely/Docker-API 1.17.0
-      Content-Type:
-      - text/plain
-  response:
-    status:
-      code: 200
-      message: 
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Sat, 10 Jan 2015 13:52:25 GMT
-      Content-Length:
-      - '40'
-    body:
-      encoding: UTF-8
-      string: |-
-        [{"Untagged":"hawknewton/true:latest"}
-        ]
-    http_version: 
-  recorded_at: Mon, 12 Jan 2015 22:21:11 GMT
+  recorded_at: Wed, 11 Feb 2015 18:06:17 GMT
 recorded_with: VCR 2.9.3

--- a/spec/vcr/Docker_Image/_create/with_a_block_capturing_create_output/calls_the_block_and_passes_build_output.yml
+++ b/spec/vcr/Docker_Image/_create/with_a_block_capturing_create_output/calls_the_block_and_passes_build_output.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<DOCKER_HOST>/v1.15/images/create?fromImage=hawknewton%2Ftrue"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.17.0
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 10 Jan 2015 13:52:23 GMT
+    body:
+      encoding: UTF-8
+      string: "{\"status\":\"Pulling repository hawknewton/true\"}\r\n{\"status\":\"Pulling
+        image (latest) from hawknewton/true\",\"progressDetail\":{},\"id\":\"5fbce35eb337\"}{\"status\":\"Pulling
+        image (latest) from hawknewton/true, endpoint: https://registry-1.docker.io/v1/\",\"progressDetail\":{},\"id\":\"5fbce35eb337\"}{\"status\":\"Pulling
+        dependent layers\",\"progressDetail\":{},\"id\":\"5fbce35eb337\"}{\"status\":\"Download
+        complete\",\"progressDetail\":{},\"id\":\"511136ea3c5a\"}{\"status\":\"Download
+        complete\",\"progressDetail\":{},\"id\":\"c0d559283422\"}{\"status\":\"Download
+        complete\",\"progressDetail\":{},\"id\":\"5fbce35eb337\"}{\"status\":\"Download
+        complete\",\"progressDetail\":{},\"id\":\"5fbce35eb337\"}{\"status\":\"Status:
+        Image is up to date for hawknewton/true\"}\r\n"
+    http_version: 
+  recorded_at: Mon, 12 Jan 2015 22:21:11 GMT
+- request:
+    method: delete
+    uri: "<DOCKER_HOST>/v1.15/images/hawknewton/true?noprune=true"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Swipely/Docker-API 1.17.0
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 10 Jan 2015 13:52:25 GMT
+      Content-Length:
+      - '40'
+    body:
+      encoding: UTF-8
+      string: |-
+        [{"Untagged":"hawknewton/true:latest"}
+        ]
+    http_version: 
+  recorded_at: Mon, 12 Jan 2015 22:21:11 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
Captures output from the `/images/create` call and makes it available to an optional block.

In addition, this PR surfaces errors thrown during local registry initialization in the `vcr:spec` rake task.

Great job here, I especially like your clean use of `let`, `subject`, and `context`.