### PR TITLE
Calling `close_write` on io if necessary

### DIFF
--- a/lib/docker/util.rb
+++ b/lib/docker/util.rb
@@ -61,7 +61,12 @@ module Docker::Util
         IO.copy_stream stdin, socket
 
         debug "hijack: closing write end of hijacked socket"
-        socket.close_write
+        closable = if socket.respond_to?(:close_write)
+          socket
+        elsif socket.respond_to?(:io)
+          socket.io
+        end
+        closable.close_write
       end
 
       debug "hijack: starting hijacked socket read thread"

--- a/lib/docker/util.rb
+++ b/lib/docker/util.rb
@@ -61,12 +61,7 @@ module Docker::Util
         IO.copy_stream stdin, socket
 
         debug "hijack: closing write end of hijacked socket"
-        closable = if socket.respond_to?(:close_write)
-          socket
-        elsif socket.respond_to?(:io)
-          socket.io
-        end
-        closable.close_write
+        close_write(socket)
       end
 
       debug "hijack: starting hijacked socket read thread"
@@ -86,6 +81,16 @@ module Docker::Util
       end
 
       threads.each(&:join)
+    end
+  end
+
+  def close_write(socket)
+    if socket.respond_to?(:close_write)
+      socket.close_write
+    elsif socket.respond_to?(:io)
+      socket.io.close_write
+    else
+      raise IOError, 'Cannot close socket'
     end
   end
 


### PR DESCRIPTION
Finishes #240 by fixing the ABC complexity error

@bfulton @nahiluhmot @jschneiderhan @myers

This seemed to work appropriately when I tried it locally. I would expect the small script I wrote (attached) to hang since the write end would never be closed, but it ends and prints the output from `cat`.

```
require 'docker'

Docker.options[:ssl_verify_peer] = false

image = Docker::Image.create('fromImage' => 'ubuntu:14.04')

container = Docker::Container.create('Image' => 'ubuntu', 'Cmd' => ['cat'], 'OpenStdin' => true, 'StdinOnce' => true)
puts container.tap(&:start).attach(stdin: StringIO.new("foo\nbar\n"))
```