### PR TITLE
fixes #260

### DIFF
--- a/lib/docker/connection.rb
+++ b/lib/docker/connection.rb
@@ -49,7 +49,7 @@ class Docker::Connection
   rescue Excon::Errors::NotFound => ex
     raise NotFoundError, ex.message
   rescue Excon::Errors::Conflict => ex
-    raise ConfictError, ex.message
+    raise ConflictError, ex.message
   rescue Excon::Errors::InternalServerError => ex
     raise ServerError, ex.response.data[:body]
   rescue Excon::Errors::Timeout => ex

--- a/lib/docker/error.rb
+++ b/lib/docker/error.rb
@@ -18,7 +18,7 @@ module Docker::Error
   class NotFoundError < DockerError; end
 
   # Raised when a request returns a 409.
-  class ConfictError < DockerError; end
+  class ConflictError < DockerError; end
 
   # Raised when a request returns a 500.
   class ServerError < DockerError; end


### PR DESCRIPTION
This is the simplest form of the fix. It will however break any code that is trying to catch `ConfictError` still. I'm not sure if that is concern, and if it is what the best approach for backward compat might be.