### PR TITLE
Option to disable ssl_verify_peer

### DIFF
--- a/.cane
+++ b/.cane
@@ -1,1 +1,2 @@
 --abc-max 16
+--style-measure 100

--- a/lib/docker.rb
+++ b/lib/docker.rb
@@ -46,6 +46,16 @@ module Docker
         client_key: File.join(cert_path, 'key.pem'),
         ssl_ca_file: File.join(cert_path, 'ca.pem'),
         scheme: 'https'
+      }.merge(ssl_options)
+    else
+      {}
+    end
+  end
+
+  def ssl_options
+    if ENV['DOCKER_SSL_VERIFY'] == 'false'
+      {
+        ssl_verify_peer: false
       }
     else
       {}
@@ -121,5 +131,5 @@ module Docker
   module_function :default_socket_url, :env_url, :url, :url=, :env_options,
                   :options, :options=, :creds, :creds=, :logger, :logger=,
                   :connection, :reset!, :reset_connection!, :version, :info,
-                  :authenticate!, :validate_version!
+                  :authenticate!, :validate_version!, :ssl_options
 end

--- a/spec/docker_spec.rb
+++ b/spec/docker_spec.rb
@@ -82,6 +82,7 @@ describe Docker do
           .and_return('tcp://someserver:8103')
         allow(ENV).to receive(:[]).with('DOCKER_CERT_PATH')
           .and_return('/boot2dockert/cert/path')
+        allow(ENV).to receive(:[]).with('DOCKER_SSL_VERIFY').and_return(nil)
         Docker.reset!
       end
 
@@ -96,6 +97,32 @@ describe Docker do
       its(:url) { should == 'tcp://someserver:8103' }
       its(:connection) { should be_a Docker::Connection }
     end
+
+    context "when the DOCKER_CERT_PATH and DOCKER_SSL_VERIFY ENV variables are set" do
+      before do
+        allow(ENV).to receive(:[]).with('DOCKER_URL').and_return(nil)
+        allow(ENV).to receive(:[]).with('DOCKER_HOST')
+          .and_return('tcp://someserver:8103')
+        allow(ENV).to receive(:[]).with('DOCKER_CERT_PATH')
+          .and_return('/boot2dockert/cert/path')
+        allow(ENV).to receive(:[]).with('DOCKER_SSL_VERIFY')
+          .and_return('false')
+        Docker.reset!
+      end
+
+      its(:options) {
+        should == {
+          client_cert: '/boot2dockert/cert/path/cert.pem',
+          client_key: '/boot2dockert/cert/path/key.pem',
+          ssl_ca_file: '/boot2dockert/cert/path/ca.pem',
+          scheme: 'https',
+          ssl_verify_peer: false
+        }
+      }
+      its(:url) { should == 'tcp://someserver:8103' }
+      its(:connection) { should be_a Docker::Connection }
+    end
+
   end
 
   describe '#reset_connection!' do


### PR DESCRIPTION
This allows the user to set ssl_verify_peer to false.
This can be required when running with a self signed cert