### PR TITLE
Enable retries for Container#wait

### DIFF
--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -16,7 +16,8 @@ class Docker::Container
   # Wait for the current command to finish executing. Default wait time is
   # `Excon.options[:read_timeout]`.
   def wait(time = nil)
-    resp = connection.post(path_for(:wait), nil, :read_timeout => time)
+    excon_params = { :read_timeout => time, :idempotent => true }
+    resp = connection.post(path_for(:wait), nil, excon_params)
     Docker::Util.parse_json(resp)
   end
 


### PR DESCRIPTION
By default, docker-api only does retries (`idempotent: true`) for GET requests.  This change is to enable retries for `Container#wait` which, while  technically idempotent without changing server state, uses POST in the API.