### PR TITLE
container name option capitalized support

### DIFF
--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -221,8 +221,7 @@ class Docker::Container
 
   # Create a new Container.
   def self.create(opts = {}, conn = Docker.connection)
-    name = opts.delete('Name')
-    name = opts.delete('name') if !name
+    name = opts.delete('Name') || opts.delete('name')
     query = {}
     query['name'] = name if name
     resp = conn.post('/containers/create', query, :body => opts.to_json)

--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -221,7 +221,8 @@ class Docker::Container
 
   # Create a new Container.
   def self.create(opts = {}, conn = Docker.connection)
-    name = opts.delete('name')
+    name = opts.delete('Name')
+    name = opts.delete('name') if !name
     query = {}
     query['name'] = name if name
     resp = conn.post('/containers/create', query, :body => opts.to_json)


### PR DESCRIPTION
Hi,
This is small fix to support capitalized container name option in Docker::Container.create method.
This is because all parameters passed in docker api are capitalized (https://docs.docker.com/reference/api/docker_remote_api_v1.12/#create-a-container) while the discussed method uses a lower case 'name' option to pass the container name to the api when the container is created, making it a little confusing to pass all options as capitalized and this specific as lower case.

Thanks.