### PR TITLE
Use reverse_each instead of reverse.each

### DIFF
--- a/lib/docker/util.rb
+++ b/lib/docker/util.rb
@@ -178,7 +178,7 @@ module Docker::Util
   end
 
   def extract_id(body)
-    body.lines.to_a.reverse.each do |line|
+    body.lines.reverse_each do |line|
       if (id = line.match(/Successfully built ([a-f0-9]+)/)) && !id[1].empty?
         return id[1]
       end


### PR DESCRIPTION
In `Docker::Util#extract_id`. 

Don't know why there was a call to `to_a`, but `lines` always returns an Array.