### PR TITLE
Correct comment intent

### DIFF
--- a/lib/docker/base.rb
+++ b/lib/docker/base.rb
@@ -6,7 +6,7 @@ module Docker::Base
   attr_accessor :connection, :info
   attr_reader :id
 
-  # The private new method accepts a connection and optional id.
+  # The private new method accepts a connection and a hash of options that must include an id.
   def initialize(connection, hash={})
     unless connection.is_a?(Docker::Connection)
       raise ArgumentError, "Expected a Docker::Connection, got: #{connection}."


### PR DESCRIPTION
Currently the initializer comment claims that the ID can be optional, but explodes if not present - this corrects the intent in the comment.