### PR TITLE
Pass in empty HostConfig hash for newer docker API versions

### DIFF
--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -223,6 +223,7 @@ class Docker::Container
   # Create a new Container.
   def self.create(opts = {}, conn = Docker.connection)
     name = opts.delete('name')
+    opts['HostConfig'] = {} if !opts['HostConfig'] && Docker.version['Version'] > '1.14'
     query = {}
     query['name'] = name if name
     resp = conn.post('/containers/create', query, :body => opts.to_json)


### PR DESCRIPTION
The newer docker daemon (at least in docker version 1.8 that I'm testing with) expects a 'HostConfig' object to exist in the request for creating a container. If it does not exist, docker will assert on a nullpointer, and the request will fail with EOF on read in the docker-api client.

docker checks for clients < v1.19 and will add in defaults to this HostConfig object. But if it doesn't exist, this error occurs.

With this patch, docker-api checks for docker's API version (> 1.14 where the HostConfig object was introduced), and adds an empty object to the request if it is not specified by the caller.

This allows Docker::Container.create() to work on the latest docker version.

This addresses: https://github.com/swipely/docker-api/issues/293 for me.