### PR TITLE
Update image.rb

### DIFF
--- a/lib/docker/image.rb
+++ b/lib/docker/image.rb
@@ -139,7 +139,7 @@ class Docker::Image
       query = {}
       query.compare_by_identity
       Array(names).each do |name|
-        query['names'] = URI.encode(name)
+        query['names'.dup] = URI.encode(name)
       end
 
       if filename


### PR DESCRIPTION
in ruby 2.2 seems the 'names' object is being optimized and is always the same object resulting in the query hash having only one entry. this small change forces 'names' to be a different object each iteration.