### PR TITLE
add user option to list passed along to exec call

### DIFF
--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -43,6 +43,7 @@ class Docker::Container
     # Establish values
     tty = opts.delete(:tty) || false
     detach = opts.delete(:detach) || false
+    user = opts.delete(:user)
     stdin = opts.delete(:stdin)
     stdout = opts.delete(:stdout) || !detach
     stderr = opts.delete(:stderr) || !detach
@@ -50,6 +51,7 @@ class Docker::Container
     # Create Exec Instance
     instance = Docker::Exec.create(
       'Container' => self.id,
+      'User' => user,
       'AttachStdin' => !!stdin,
       'AttachStdout' => stdout,
       'AttachStderr' => stderr,


### PR DESCRIPTION
Parameter is "user" with the value equal to the in-container username.

Example:

> docker_obj = Docker::Container.get("mycontainer")
> cmd = { "/bin/sh", "ls", "/" }
> opts = { :user => "nobody" }
> docker_obj.exec(cmd,opts)

The Docker engine will use the default value for user if the parameter provided is an empty string, so this should be safe. Tested against Docker 1.7.1 (boot2docker).