### PR TITLE
Add reference mapping to docker commands - #305

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ require 'docker'
 # => true
 
 # Pull an Image.
-# docker command for reference: docker pull base, you need replace "base" with real docker image.
-image = Docker::Image.create('fromImage' => 'base')
+# docker command for reference: docker pull alpine:3.2
+image = Docker::Image.create('fromImage' => 'alpine:3.2')
 # => Docker::Image { :id => ae7ffbcd1, :connection => Docker::Connection { :url => tcp://localhost, :options => {:port=>2375} } }
 
 # Insert a local file into an Image.

--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ require 'docker'
 # => true
 
 # Pull an Image.
-# docker command for reference: docker pull alpine:3.2
-image = Docker::Image.create('fromImage' => 'alpine:3.2')
+# docker command for reference: docker pull ubuntu:14.04
+image = Docker::Image.create('fromImage' => 'ubuntu:14.04')
 # => Docker::Image { :id => ae7ffbcd1, :connection => Docker::Connection { :url => tcp://localhost, :options => {:port=>2375} } }
 
 # Insert a local file into an Image.

--- a/README.md
+++ b/README.md
@@ -102,12 +102,15 @@ All of the following examples require a connection to a Docker server. See the <
 require 'docker'
 # => true
 
+# docker command for reference: docker version
 Docker.version
 # => { 'Version' => '0.5.2', 'GoVersion' => 'go1.1' }
 
+# docker command for reference: docker info 
 Docker.info
 # => { "Debug" => false, "Containers" => 187, "Images" => 196, "NFd" => 10, "NGoroutines" => 9, "MemoryLimit" => true }
 
+# docker command for reference: docker login
 Docker.authenticate!('username' => 'docker-fan-boi', 'password' => 'i<3docker', 'email' => 'dockerboy22@aol.com')
 # => true
 ```
@@ -120,7 +123,8 @@ Just about every method here has a one-to-one mapping with the [Images](https://
 require 'docker'
 # => true
 
-# Create an Image.
+# Pull an Image.
+# docker command for reference: docker pull base, you need replace "base" with real docker image.
 image = Docker::Image.create('fromImage' => 'base')
 # => Docker::Image { :id => ae7ffbcd1, :connection => Docker::Connection { :url => tcp://localhost, :options => {:port=>2375} } }
 


### PR DESCRIPTION
When read the usage, I do find it is hard to get quick understanding to mapping the ruby gem with real docker commands. 

Add comments in README for a quick start. If you like this way, I will add the rest. 

Second, when do the sample to pull image, the command use a fake image named `base`, change it to a real and tiny one, developer can quickly understand how to use it properly 