### PR TITLE
Make Container#wait respect the given timeout.

### DIFF
--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -16,7 +16,7 @@ class Docker::Container
   # Wait for the current command to finish executing. Default wait time is
   # `Excon.options[:read_timeout]`.
   def wait(time = nil)
-    excon_params = { :read_timeout => time, :idempotent => true }
+    excon_params = { :read_timeout => time }
     resp = connection.post(path_for(:wait), nil, excon_params)
     Docker::Util.parse_json(resp)
   end


### PR DESCRIPTION
Setting `idempotent: true` on the wait request allows excon to retry it. By default, excon seems to retry idempotent failed requests 4 times, and this number can be controlled by the `:retry_limit` option. This means the actual time `Container#wait` waits before giving up is 4 * the given time, on a system without custom Excon options.

VCR asserts don't seem to include idempotency or timeouts, so there are no changes to the test suite. However, I did test this patch on a live system. The retries can be observed by setting the `EXCON_DEBUG=1` environment variable and running `docker-api`-based tests.

Please please please consider merging this or a similar fix. I spent quite a bit of time tracing the root of the timeout issue.

Also, as always, many thanks for this wonderful gem! :heart: 