### PR TITLE
Show people how to stream the build logs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,13 @@ Docker::Image.build("from base\nrun touch /test")
 Docker::Image.build_from_dir('.')
 # => Docker::Image { :id => 1266dc19e, :connection => Docker::Connection { :url => tcp://localhost, :options => {:port=>2375} } }
 
+# Create an Image from a Dockerfile and stream the logs
+Docker::Image.build_from_dir('.') do |v|
+  if (log = JSON.parse(v)) && log.has_key?("stream")
+    $stdout.puts log["stream"]
+  end
+end
+
 # Create an Image from a tar file.
 # docker command for reference: docker build - < docker_image.tar
 Docker::Image.build_from_tar(File.open('docker_image.tar', 'r'))


### PR DESCRIPTION
It took a second to figure out how to stream the logs on our builds, finally we stepped into our context and inspected the methods to find out that builds accepted a block and passed the returned data so we would like that noted so other people can quickly find it without trouble.