### PR TITLE
Simplify Bundler usage with docker-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Installation
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'docker-api', :require => 'docker'
+gem 'docker-api'
 ```
 
 And then run:

--- a/lib/docker-api.rb
+++ b/lib/docker-api.rb
@@ -1,0 +1,1 @@
+require 'docker'


### PR DESCRIPTION
With this small addition, users no longer need `require 'docker'` in their Gemfile.