### PR TITLE
Update all Docker::Container#exec examples  to use an Array.

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ container.exec(['./my_service'], detach: true)
 # => Docker::Exec { :id => be4eaeb8d28a, :connection => Docker::Connection { :url => tcp://localhost, :options => {:port=>2375} } }
 
 # Parse the output of an Exec instance
-container.exec(['find / -name *']) { |stream, chunk| puts "#{stream}: #{chunk}" }
+container.exec(['find', '/', '-name *']) { |stream, chunk| puts "#{stream}: #{chunk}" }
 stderr: 2013/10/30 17:16:24 Unable to locate find / -name *
 # => [[], ["2013/10/30 17:16:24 Unable to locate find / -name *\n"], 1]
 

--- a/README.md
+++ b/README.md
@@ -387,24 +387,24 @@ container.run('pwd', 10)
 # => Docker::Image { :id => 4427be4199ac, :connection => Docker::Connection { :url => tcp://localhost, :options => {:port=>2375} } }
 
 # Run an Exec instance inside the container and capture its output and exit status
-container.exec('date')
+container.exec(['date'])
 # => [["Wed Nov 26 11:10:30 CST 2014\n"], [], 0]
 
 # Launch an Exec instance without capturing its output or status
-container.exec('./my_service', detach: true)
+container.exec(['./my_service'], detach: true)
 # => Docker::Exec { :id => be4eaeb8d28a, :connection => Docker::Connection { :url => tcp://localhost, :options => {:port=>2375} } }
 
 # Parse the output of an Exec instance
-container.exec('find / -name *') { |stream, chunk| puts "#{stream}: #{chunk}" }
+container.exec(['find / -name *']) { |stream, chunk| puts "#{stream}: #{chunk}" }
 stderr: 2013/10/30 17:16:24 Unable to locate find / -name *
 # => [[], ["2013/10/30 17:16:24 Unable to locate find / -name *\n"], 1]
 
 # Run an Exec instance by grab only the STDOUT output
-container.exec('date', stderr: false)
+container.exec(['date'], stderr: false)
 # => [["Wed Nov 26 11:10:30 CST 2014\n"], [], 0]
 
 # Pass input to an Exec instance command via Stdin
-container.exec('cat', stdin: StringIO.new("foo\nbar\n"))
+container.exec(['cat'], stdin: StringIO.new("foo\nbar\n"))
 # => [["foo\nbar\n"], [], 0]
 
 # Get the raw stream of data from an Exec instance


### PR DESCRIPTION
The documentation implies that you can send a plain string but this
is not true, as Docker will flip out and go crazy when that happens so the
solution here is to send an Array.