### PR TITLE
Add network command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ services:
   - docker
 cache: bundler
 language: ruby
+before_script:
+  - docker version
 rvm:
   - 1.9.3
   - 2.0

--- a/lib/docker.rb
+++ b/lib/docker.rb
@@ -23,6 +23,7 @@ module Docker
   require 'docker/connection'
   require 'docker/base'
   require 'docker/container'
+  require 'docker/network'
   require 'docker/event'
   require 'docker/exec'
   require 'docker/image'

--- a/lib/docker/network.rb
+++ b/lib/docker/network.rb
@@ -1,0 +1,56 @@
+# This class represents a Docker Network.
+class Docker::Network
+  include Docker::Base
+
+  def connect(container, opts = {})
+    Docker::Util.parse_json(connection.post(path_for('connect'), opts, body: {container: container}.to_json))
+  end
+
+  def disconnect(container, opts = {})
+    Docker::Util.parse_json(connection.post(path_for('disconnect'), opts, body: {container: container}.to_json))
+  end
+
+  # remove network
+  def remove(opts = {})
+    connection.delete(path_for, opts)
+    nil
+  end
+  alias_method :delete, :remove
+
+  def json(opts = {})
+    Docker::Util.parse_json(connection.get(path_for, opts))
+  end
+
+  class << self
+    def create(opts = {}, conn = Docker.connection)
+      default_opts = {
+        'CheckDuplicate' => true
+      }
+      name = opts.delete('name')
+      query = {}
+      query['name'] = name if name
+      resp = conn.post('/networks/create', query, :body => default_opts.merge(opts).to_json)
+      hash = Docker::Util.parse_json(resp) || {}
+      new(conn, hash)
+    end
+
+    def get(id, opts = {}, conn = Docker.connection)
+      network_json = conn.get("/networks/#{URI.encode(id)}", opts)
+      hash = Docker::Util.parse_json(network_json) || {}
+      new(conn, hash)
+    end
+
+    def all(opts = {}, conn = Docker.connection)
+      hashes = Docker::Util.parse_json(conn.get('/networks', opts)) || []
+      hashes.map { |hash| new(conn, hash) }
+    end
+  end
+
+  # Convenience method to return the path for a particular resource.
+  def path_for(resource = nil)
+    ["/networks/#{id}", resource].compact.join('/')
+  end
+
+  private :path_for
+  private_class_method :new
+end

--- a/lib/docker/network.rb
+++ b/lib/docker/network.rb
@@ -54,6 +54,12 @@ class Docker::Network
       hashes = Docker::Util.parse_json(conn.get('/networks', opts)) || []
       hashes.map { |hash| new(conn, hash) }
     end
+
+    def remove(id, opts = {}, conn = Docker.connection)
+      conn.delete("/networks/#{URI.encode(id)}", opts)
+      nil
+    end
+    alias_method :delete, :remove
   end
 
   # Convenience method to return the path for a particular resource.

--- a/lib/docker/network.rb
+++ b/lib/docker/network.rb
@@ -7,6 +7,7 @@ class Docker::Network
       connection.post(path_for('connect'), opts,
                       body: { container: container }.to_json)
     )
+    reload
   end
 
   def disconnect(container, opts = {})
@@ -14,9 +15,9 @@ class Docker::Network
       connection.post(path_for('disconnect'), opts,
                       body: { container: container }.to_json)
     )
+    reload
   end
 
-  # remove network
   def remove(opts = {})
     connection.delete(path_for, opts)
     nil
@@ -30,6 +31,12 @@ class Docker::Network
   def to_s
     "Docker::Network { :id => #{id}, :info => #{info.inspect}, "\
       ":connection => #{connection} }"
+  end
+
+  def reload
+    network_json = @connection.get("/networks/#{URI.encode(@id)}")
+    hash = Docker::Util.parse_json(network_json) || {}
+    @info = hash
   end
 
   class << self
@@ -68,5 +75,4 @@ class Docker::Network
   end
 
   private :path_for
-  private_class_method :new
 end

--- a/lib/docker/network.rb
+++ b/lib/docker/network.rb
@@ -33,17 +33,15 @@ class Docker::Network
   end
 
   class << self
-    def create(opts = {}, conn = Docker.connection)
+    def create(name, opts = {}, conn = Docker.connection)
       default_opts = {
+        'Name' => name,
         'CheckDuplicate' => true
       }
-      name = opts.delete('name')
-      query = {}
-      query['name'] = name if name
-      resp = conn.post('/networks/create', query,
+      resp = conn.post('/networks/create', {},
                        body: default_opts.merge(opts).to_json)
-      hash = Docker::Util.parse_json(resp) || {}
-      new(conn, hash)
+      response_hash = Docker::Util.parse_json(resp) || {}
+      get(response_hash['Id']) || {}
     end
 
     def get(id, opts = {}, conn = Docker.connection)

--- a/lib/docker/network.rb
+++ b/lib/docker/network.rb
@@ -3,11 +3,17 @@ class Docker::Network
   include Docker::Base
 
   def connect(container, opts = {})
-    Docker::Util.parse_json(connection.post(path_for('connect'), opts, body: {container: container}.to_json))
+    Docker::Util.parse_json(
+      connection.post(path_for('connect'), opts,
+                      body: { container: container }.to_json)
+    )
   end
 
   def disconnect(container, opts = {})
-    Docker::Util.parse_json(connection.post(path_for('disconnect'), opts, body: {container: container}.to_json))
+    Docker::Util.parse_json(
+      connection.post(path_for('disconnect'), opts,
+                      body: { container: container }.to_json)
+    )
   end
 
   # remove network
@@ -21,6 +27,11 @@ class Docker::Network
     Docker::Util.parse_json(connection.get(path_for, opts))
   end
 
+  def to_s
+    "Docker::Network { :id => #{id}, :info => #{info.inspect}, "\
+      ":connection => #{connection} }"
+  end
+
   class << self
     def create(opts = {}, conn = Docker.connection)
       default_opts = {
@@ -29,7 +40,8 @@ class Docker::Network
       name = opts.delete('name')
       query = {}
       query['name'] = name if name
-      resp = conn.post('/networks/create', query, :body => default_opts.merge(opts).to_json)
+      resp = conn.post('/networks/create', query,
+                       body: default_opts.merge(opts).to_json)
       hash = Docker::Util.parse_json(resp) || {}
       new(conn, hash)
     end

--- a/spec/docker/network_spec.rb
+++ b/spec/docker/network_spec.rb
@@ -1,0 +1,150 @@
+require 'spec_helper'
+
+describe Docker::Network do
+  let(:name) do |example|
+    example.description.downcase.gsub('\s', '-')
+  end
+
+  describe '#to_s' do
+    subject { described_class.new(Docker.connection, info) }
+    let(:connection) { Docker.connection }
+
+    let(:id) do
+      'a6c5ffd25e07a6c906accf804174b5eb6a9d2f9e07bccb8f5aa4f4de5be6d01d'
+    end
+
+    let(:info) do
+      {
+        'Name' => 'bridge',
+        'Scope' => 'local',
+        'Driver' => 'bridge',
+        'IPAM' => {
+          'Driver' => 'default',
+          'Config' => [{ 'Subnet' => '172.17.0.0/16' }]
+        },
+        'Containers' => {},
+        'Options' => {
+          'com.docker.network.bridge.default_bridge' => 'true',
+          'com.docker.network.bridge.enable_icc' => 'true',
+          'com.docker.network.bridge.enable_ip_masquerade' => 'true',
+          'com.docker.network.bridge.host_binding_ipv4' => '0.0.0.0',
+          'com.docker.network.bridge.name' => 'docker0',
+          'com.docker.network.driver.mtu' => '1500'
+        },
+        'id' => id
+      }
+    end
+
+    let(:expected_string) do
+      "Docker::Network { :id => #{id}, :info => #{info.inspect}, "\
+        ":connection => #{connection} }"
+    end
+
+    its(:to_s) { should == expected_string }
+  end
+
+  describe '.create' do
+    let!(:id) { subject.id }
+    subject { described_class.create(name) }
+    after { described_class.remove(id) }
+
+    it 'creates a Network' do
+      expect(Docker::Network.all.map(&:id)).to include(id)
+    end
+  end
+
+  describe '.remove' do
+    let(:id) { subject.id }
+    subject { described_class.create(name) }
+
+    it 'removes the Network' do
+      described_class.remove(id)
+      expect(Docker::Network.all.map(&:id)).to_not include(id)
+    end
+  end
+
+  describe '.get' do
+    after do
+      described_class.remove(name)
+    end
+
+    let!(:network) { described_class.create(name) }
+
+    it 'returns a network' do
+      expect(Docker::Network.get(name).id).to eq(network.id)
+    end
+  end
+
+  describe '.all' do
+    let!(:networks) do
+      5.times.map { |i| described_class.create("#{name}-#{i}") }
+    end
+
+    after do
+      networks.each(&:remove)
+    end
+
+    it 'should return all networks' do
+      expect(Docker::Network.all.map(&:id)).to include(*networks.map(&:id))
+    end
+  end
+
+  describe '#connect' do
+    let!(:container) do
+      Docker::Container.create(
+        'Cmd' => %w(sleep 10),
+        'Image' => 'debian:wheezy'
+      )
+    end
+    subject { described_class.create(name) }
+
+    before(:each) { container.start }
+    after(:each) do
+      container.kill!.remove
+      subject.remove
+    end
+
+    it 'connects a container to a network' do
+      subject.connect(container.id)
+      expect(subject.info['Containers']).to include(container.id)
+    end
+  end
+
+  describe '#disconnect' do
+    let!(:container) do
+      Docker::Container.create(
+        'Cmd' => %w(sleep 10),
+        'Image' => 'debian:wheezy'
+      )
+    end
+
+    subject { described_class.create(name) }
+
+    before(:each) do
+      container.start
+      sleep 1
+      subject.connect(container.id)
+    end
+
+    after(:each) do
+      container.kill!.remove
+      subject.remove
+    end
+
+    it 'connects a container to a network' do
+      subject.disconnect(container.id)
+      expect(subject.info['Containers']).not_to include(container.id)
+    end
+  end
+
+  describe '#remove' do
+    let(:id) { subject.id }
+    let(:name) { 'test-network-remove' }
+    subject { described_class.create(name) }
+
+    it 'removes the Network' do
+      subject.remove
+      expect(Docker::Network.all.map(&:id)).to_not include(id)
+    end
+  end
+end

--- a/spec/docker/network_spec.rb
+++ b/spec/docker/network_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Docker::Network do
+describe Docker::Network, docker_1_9: true do
   let(:name) do |example|
     example.description.downcase.gsub('\s', '-')
   end


### PR DESCRIPTION
This will add the basic `docker network` commands. It will make it possible to create, delete, connect, disconnect and list docker networks.

There are no tests. I ran the test suite and there are so many tests not working with docker 1.9. I started fixing all the tests but then I will break the tests on older versions of docker.