### PR TITLE
Modifying gemspec to only include essential files in the gem artifact.

### DIFF
--- a/docker-api.gemspec
+++ b/docker-api.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{A simple REST client for the Docker Remote API}
   gem.homepage      = 'https://github.com/swipely/docker-api'
   gem.license       = 'MIT'
-  gem.files         = `git ls-files`.split($\)
+  gem.files         = `git ls-files`.split($\).grep(/LICENSE|^CHANGELOG|^lib/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "docker-api"


### PR DESCRIPTION
This chops off about a megabyte, and fixes on Windows where it had
trouble loading a long pathname under spec/vcr.