### PR TITLE
fix regression with symbolized fromImage option on Image#create

### DIFF
--- a/lib/docker/image.rb
+++ b/lib/docker/image.rb
@@ -116,7 +116,7 @@ class Docker::Image
       completions = json.compact.select { |j| j['status'] && j['status'].include?('complete') }
       if image = completions.reverse_each.find { |j| j['id'] }
         get(image['id'], {}, conn)
-      elsif image = opts['fromImage']
+      elsif image = opts['fromImage'] || opts[:fromImage]
         get(image, {}, conn)
       end
     end


### PR DESCRIPTION
Check for a fromImage option as both string and symbols, this way

> create('fromImage' => 'foo')

behaves again like

> create(fromImage: 'foo')

to restore compatibility with pre-1.24 behavior.