### PR TITLE
Add json encoded values example

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,11 +429,29 @@ Docker::Container.get('500f53b25e6e')
 # Request all of the Containers. By default, will only return the running Containers.
 Docker::Container.all(:all => true)
 # => [Docker::Container { :id => , :connection => Docker::Connection { :url => tcp://localhost, :options => {:port=>2375} } }]
+```
+
+## JSON encoded values
+
+For JSON encoded values, nothing is done implicitly, meaning you need to explicitly call `to_json` on your parameter before the call. For example, to request all of the Containers using a filter:
+
+```ruby
+require 'docker'
 
 # Request all of the Containers, filtering by status exited.
 Docker::Container.all(all: true, filters: { status: ["exited"] }.to_json)
 # => [Docker::Container { :id => , :connection => Docker::Connection { :url => tcp://localhost, :options => {:port=>2375} } }]
+
+# Request all of the Container, filtering by label_name.
+Docker::Container.all(all: true, filters: { label: [ "label_name"  ]  }.to_json)
+# => [Docker::Container { :id => , :connection => Docker::Connection { :url => tcp://localhost, :options => {:port=>2375} } }]
+
+# Request all of the Container, filtering by label label_name that have the value label_value_.
+Docker::Container.all(all: true, filters: { label: [ "label_name=label_value"  ]  }.to_json)
+# => [Docker::Container { :id => , :connection => Docker::Connection { :url => tcp://localhost, :options => {:port=>2375} } }]
 ```
+
+This applies for all parameters that are requested to be JSON encoded by the docker api.
 
 ## Events
 
@@ -453,26 +471,6 @@ Docker::Event { :status => die, :id => 663005cdeb56f50177c395a817dbc8bdcfbdfbdae
 ```
 
 These methods are prone to read timeouts.  `Docker.options[:read_timeout]` will need to be made higher than 60 seconds if expecting a long time between events.
-
-## JSON encoded values
-
-For JSON encoded values, nothing is done implicitly, meaning you need to explicitly call `to_json` on your parameter before the call. For example, to get a list of all exited container :
-
-```
-Docker::Container.all(all: 1, filters: { status: [ "exited"  ]  }.to_json)
-```
-
-Or to filter the container list with a label :
-
-```
-Docker::Container.all(all: 1, filters: { label: [ "label_name"  ]  }.to_json)
-```
-
-To find a specific value associated to a label :
-
-```
-Docker::Container.all(all: 1, filters: { label: [ "label_name=label_value"  ]  }.to_json)
-```
 
 ## Connecting to Multiple Servers
 

--- a/README.md
+++ b/README.md
@@ -454,6 +454,26 @@ Docker::Event { :status => die, :id => 663005cdeb56f50177c395a817dbc8bdcfbdfbdae
 
 These methods are prone to read timeouts.  `Docker.options[:read_timeout]` will need to be made higher than 60 seconds if expecting a long time between events.
 
+## JSON encoded values
+
+For JSON encoded values, nothing is done implicitly, meaning you need to explicitly call `to_json` on your parameter before the call. For example, to get a list of all exited container :
+
+```
+Docker::Container.all(all: 1, filters: { status: [ "exited"  ]  }.to_json)
+```
+
+Or to filter the container list with a label :
+
+```
+Docker::Container.all(all: 1, filters: { label: [ "label_name"  ]  }.to_json)
+```
+
+To find a specific value associated to a label :
+
+```
+Docker::Container.all(all: 1, filters: { label: [ "label_name=label_value"  ]  }.to_json)
+```
+
 ## Connecting to Multiple Servers
 
 By default, each object connects to the connection specified by `Docker.connection`. If you need to connect to multiple servers, you can do so by specifying the connection on `#new` or in the utilizing class method. For example:


### PR DESCRIPTION
Added et rewrote example related to #361.

As I wrote the examples, I noticed that there was already an example as the last line of the Containers section but unfortunately I missed it during my troubleshooting. I tried to make it more explicit for newcomers by creating a new section related to JSON encoded values.