### PR TITLE
Docker::Image.run method should support passing additional options

### DIFF
--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -51,26 +51,28 @@ class Docker::Container
   # @param options [Hash] The options to pass to Docker::Exec
   #
   # @return [Docker::Exec] The Exec instance
-  def exec(command, opts = {}, &block)
+  def exec(command, options = {}, &block)
     # Establish values
-    tty = opts.delete(:tty) || false
-    detach = opts.delete(:detach) || false
-    user = opts.delete(:user)
-    stdin = opts.delete(:stdin)
-    stdout = opts.delete(:stdout) || !detach
-    stderr = opts.delete(:stderr) || !detach
+    tty = options.delete(:tty) || false
+    detach = options.delete(:detach) || false
+    user = options.delete(:user)
+    stdin = options.delete(:stdin)
+    stdout = options.delete(:stdout) || !detach
+    stderr = options.delete(:stderr) || !detach
+
+    opts = {
+      'Container' => self.id,
+      'User' => user,
+      'AttachStdin' => !!stdin,
+      'AttachStdout' => stdout,
+      'AttachStderr' => stderr,
+      'Tty' => tty,
+      'Cmd' => command
+    }.merge(options)
 
     # Create Exec Instance
     instance = Docker::Exec.create(
-      {
-        'Container' => self.id,
-        'User' => user,
-        'AttachStdin' => !!stdin,
-        'AttachStdout' => stdout,
-        'AttachStderr' => stderr,
-        'Tty' => tty,
-        'Cmd' => command
-      },
+      opts,
       self.connection
     )
 

--- a/lib/docker/image.rb
+++ b/lib/docker/image.rb
@@ -6,8 +6,8 @@ class Docker::Image
   # an Image. This will not modify the Image, but rather create a new Container
   # to run the Image. If the image has an embedded config, no command is
   # necessary, but it will fail with 500 if no config is saved with the image
-  def run(cmd=nil)
-    opts = { 'Image' => self.id }
+  def run(cmd = nil, options = {})
+    opts = {'Image' => self.id}.merge(options)
     opts["Cmd"] = cmd.is_a?(String) ? cmd.split(/\s+/) : cmd
     begin
       Docker::Container.create(opts, connection)

--- a/spec/docker/image_spec.rb
+++ b/spec/docker/image_spec.rb
@@ -216,11 +216,18 @@ describe Docker::Image do
   end
 
   describe '#run' do
-    subject { described_class.create('fromImage' => 'debian:wheezy') }
-    let(:container) { subject.run(cmd).tap(&:wait) }
+    let(:cmd) { nil }
+    let(:options) { {} }
+
+    subject do
+      described_class.create(
+        {'fromImage' => 'debian:wheezy'})
+    end
+
+    let(:container) { subject.run(cmd, options).tap(&:wait) }
     let(:output) { container.streaming_logs(stdout: true) }
 
-    context 'when the argument is a String' do
+    context 'when cmd is a String' do
       let(:cmd) { 'ls /lib64/' }
       after { container.remove }
 
@@ -229,7 +236,7 @@ describe Docker::Image do
       end
     end
 
-    context 'when the argument is an Array' do
+    context 'when cmd is an Array' do
       let(:cmd) { %w[which pwd] }
       after { container.remove }
 
@@ -238,7 +245,7 @@ describe Docker::Image do
       end
     end
 
-    context 'when the argument is nil'  do
+    context 'when cmd is nil'  do
       let(:cmd) { nil }
       context 'no command configured in image' do
         subject { described_class.create('fromImage' => 'swipely/base') }
@@ -255,6 +262,15 @@ describe Docker::Image do
         it 'should normally show result if image has Cmd configured' do
           expect(output).to eql "/\n"
         end
+      end
+    end
+
+    context 'when using cpu shares' do
+      let(:options) { { 'CpuShares' => 50 } }
+      after { container.remove }
+
+      it 'returns 50' do
+        expect(container.json["Config"]["CpuShares"]).to eq 50
       end
     end
   end


### PR DESCRIPTION
Hi,

before adding the necessary tests, I wanted to understand if this PR is acceptable. I guess it is useful to specify the container options upon creation (equivalent of docker run [options] cmd)

Let me know!
Matteo