### PR TITLE
Add remove on image class

### DIFF
--- a/lib/docker/image.rb
+++ b/lib/docker/image.rb
@@ -128,6 +128,12 @@ class Docker::Image
       new(conn, hash)
     end
 
+    # Delete a specific image
+    def remove(id, opts = {}, conn = Docker.connection)
+      conn.delete("/images/#{id}", opts)
+    end
+    alias_method :delete, :remove
+
     # Save the raw binary representation or one or more Docker images
     #
     # @param names [String, Array#String] The image(s) you wish to save

--- a/spec/docker/image_spec.rb
+++ b/spec/docker/image_spec.rb
@@ -33,6 +33,17 @@ describe Docker::Image do
       end
     end
 
+    context 'when using the class' do
+      let(:id) { subject.id }
+      subject { described_class.create('fromImage' => 'busybox:latest') }
+      after { described_class.create('fromImage' => 'busybox:latest') }
+
+      it 'removes the Image' do
+        Docker::Image.remove(id, force: true)
+        expect(Docker::Image.all.map(&:id)).to_not include(id)
+      end
+    end
+
     context 'when a valid tag is given' do
       it 'untags the Image'
     end


### PR DESCRIPTION
Add the remove method on the class level to avoid instanciation unnecessary calls if you just want to be certain that an image has been removed from your docker host (no need to do exists? or get().remove).