### PR TITLE
Add possibility to call GET /_ping endpoint using Docker.ping

### DIFF
--- a/lib/docker.rb
+++ b/lib/docker.rb
@@ -112,6 +112,11 @@ module Docker
     Util.parse_json(connection.get('/info'))
   end
 
+  # Ping the Docker server.
+  def ping(connection = self.connection)
+    connection.get('/_ping')
+  end
+
   # Login to the Docker registry.
   def authenticate!(options = {}, connection = self.connection)
     creds = options.to_json
@@ -134,5 +139,5 @@ module Docker
   module_function :default_socket_url, :env_url, :url, :url=, :env_options,
                   :options, :options=, :creds, :creds=, :logger, :logger=,
                   :connection, :reset!, :reset_connection!, :version, :info,
-                  :authenticate!, :validate_version!, :ssl_options
+                  :ping, :authenticate!, :validate_version!, :ssl_options
 end

--- a/spec/docker_spec.rb
+++ b/spec/docker_spec.rb
@@ -183,6 +183,16 @@ describe Docker do
     end
   end
 
+  describe '#ping' do
+    before { Docker.reset! }
+
+    let(:ping) { subject.ping}
+
+    it 'returns the status as a String' do
+      expect(ping).to eq('OK')
+    end
+  end
+
   describe '#authenticate!' do
     subject { described_class }
 


### PR DESCRIPTION
Add the possibility to monitor the health of the docker daemon using the ping endpoint of the docker api.