### PR TITLE
1.10.x Images - always return imageid fromImage instead of searching response body

### DIFF
--- a/lib/docker/image.rb
+++ b/lib/docker/image.rb
@@ -111,14 +111,9 @@ class Docker::Image
         opts,
         :headers => headers,
         :response_block => response_block(body, &block)
-      )
-      json = Docker::Util.fix_json(body)
-      completions = json.compact.select { |j| j['status'] && j['status'].include?('complete') }
-      if image = completions.reverse_each.find { |j| j['id'] }
-        get(image['id'], {}, conn)
-      elsif image = opts['fromImage'] || opts[:fromImage]
-        get(image, {}, conn)
-      end
+        )
+      image = opts['fromImage'] || opts[:fromImage]
+      get(image, {}, conn)
     end
 
     # Return a specific image.


### PR DESCRIPTION
This should fix Image.create on Docker 1.10.x