### PR TITLE
Add container stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,10 @@ container = Docker::Container.create('Image' => 'ubuntu', 'Cmd' => command, 'Tty
 container.tap(&:start).attach(:tty => true)
 # => [["I'm a TTY!"], []]
 
+# Obtaining the current statistics of a container
+container.stats
+# => {"read"=>"2016-02-29T20:47:05.221608695Z", "precpu_stats"=>{"cpu_usage"=> ... }
+
 # Create an Image from a Container's changes.
 container.commit
 # => Docker::Image { :id => eaeb8d00efdf, :connection => Docker::Connection { :url => tcp://localhost, :options => {:port=>2375} } }

--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -156,6 +156,11 @@ class Docker::Container
     connection.get(path_for(:logs), opts)
   end
 
+  # TODO: Implement Streaming stats
+  def stats
+    Docker::Util.parse_json(connection.get(path_for(:stats), {stream: 0}))
+  end
+
   def rename(new_name)
     query = {}
     query['name'] = new_name

--- a/spec/docker/container_spec.rb
+++ b/spec/docker/container_spec.rb
@@ -81,6 +81,20 @@ describe Docker::Container do
     end
   end
 
+  describe '#stats' do
+    subject {
+      described_class.create('Cmd' => "echo hello", 'Image' => 'debian:wheezy')
+    }
+    after(:each) { subject.remove }
+
+    context "when requesting container stats" do
+      let(:output) { subject.stats }
+      it "returns a Hash" do
+        expect(output).to be_a Hash
+      end
+    end
+  end
+
   describe '#logs' do
     subject {
       described_class.create('Cmd' => "echo hello", 'Image' => 'debian:wheezy')


### PR DESCRIPTION
This one is really simple, and implements the non-streaming stats endpoint with a basic spec.

I toyed around with adding the streaming stats as well, but found them to be rather pointless b/c you have no control of the interval, whereas this may prove more beneficial (in pseudo i-didn't-feel-like-writing-and-testing-a-real-example code):

```ruby
require 'docker-api'
require 'my-nonexistent-influxdb-library'
influxdb = Influxdb.connect(...)
while true
  begin
    stats = Docker::Container.get('my-container').stats
    influxdb.lineprotocol_write("docker.container_stats,name=my-container cpu_total=#{stats["cpu_stats"]["cpu_usage"]["total_usage"]} #{Influxdb::Util.convert_ts_to_ns(stats["read"])}")
    sleep 5
  rescue
    ...
  end
end
```