### PR TITLE
Convenience methods for containers: read_file and store_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ require 'docker'
 Docker.version
 # => { 'Version' => '0.5.2', 'GoVersion' => 'go1.1' }
 
-# docker command for reference: docker info 
+# docker command for reference: docker info
 Docker.info
 # => { "Debug" => false, "Containers" => 187, "Images" => 196, "NFd" => 10, "NGoroutines" => 9, "MemoryLimit" => true }
 
@@ -299,6 +299,13 @@ container.kill(:signal => "SIGHUP")
 # Return the currently executing processes in a Container.
 container.top
 # => [{"PID"=>"4851", "TTY"=>"pts/0", "TIME"=>"00:00:00", "CMD"=>"lxc-start"}]
+
+# Stores a file with the given content in the container
+container.store_file("/test", "Hello world")
+
+# Reads a file from the container
+container.read_file("/test")
+# => "Hello world"
 
 # Export a Container. Since an export is typically at least 300M, chunks of the
 # export are yielded instead of just returning the whole thing.

--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -269,6 +269,31 @@ class Docker::Container
     self
   end
 
+  def read_file(path)
+    content = StringIO.new
+    archive_out(path) do |chunk|
+      content.write chunk
+    end
+
+    content.rewind
+
+    Gem::Package::TarReader.new(content) do |tar|
+      tar.each do |tarfile|
+        return tarfile.read
+      end
+    end
+  end
+
+  def store_file(path, file_content)
+    output_io = StringIO.new(
+      Docker::Util.create_tar(
+        path => file_content
+      )
+    )
+
+    archive_in_stream("/", overwrite: true) { output_io.read }
+  end
+
   # Create a new Container.
   def self.create(opts = {}, conn = Docker.connection)
     name = opts.delete('name')

--- a/spec/docker/container_spec.rb
+++ b/spec/docker/container_spec.rb
@@ -311,6 +311,32 @@ describe Docker::Container do
     end
   end
 
+  describe "#read_file", :docker_1_8 do
+    subject { Docker::Container.create("Image" => "debian:wheezy", "Cmd" => ["/bin/bash", "-c", "echo \"Hello world\" > /test"]) }
+
+    after { subject.remove }
+
+    before do
+      subject.start
+      subject.wait
+    end
+
+    it "reads contents from files" do
+      expect(subject.read_file("/test")).to eq "Hello world\n"
+    end
+  end
+
+  describe "#store_file", :docker_1_8 do
+    subject { Docker::Container.create('Image' => 'debian:wheezy', 'Cmd' => ["ls"]) }
+
+    after { subject.remove }
+
+    it "stores content in files" do
+      subject.store_file("/test", "Hello\nWorld")
+      expect(subject.read_file("/test")).to eq "Hello\nWorld"
+    end
+  end
+
   describe '#export' do
     subject { described_class.create('Cmd' => %w[/true],
                                      'Image' => 'tianon/true') }


### PR DESCRIPTION
I would like to propose adding some convenience methods for reading and storing files on containers.

It was pretty complicated for me to find out how to do this. I had to read up on the undocumented archive methods, which I would like to help future developers around by adding the following convenience methods for reading and storing files easily.