### PR TITLE
Add image save stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@ image.save('my_export.tar')
 image.save
 # => "abiglongbinarystring"
 
+# Stream the contents of the image to a block:
+image.save_stream { |chunk| puts chunk }
+# => nil
+
 # Given a Container's export, creates a new Image.
 # docker command for reference: docker import some-export.tar
 Docker::Image.import('some-export.tar')
@@ -251,6 +255,11 @@ Docker::Image.save(names, 'my_export.tar')
 names = %w( my_image1 my_image2:not_latest )
 Docker::Image.save(names)
 # => "abiglongbinarystring"
+
+# Stream the raw binary data
+names = %w( my_image1 my_image2:not_latest )
+Docker::Image.save_stream(names) { |chunk| puts chunk }
+# => nil
 
 # Search the Docker registry.
 # docker command for reference: docker search sshd

--- a/spec/docker/image_spec.rb
+++ b/spec/docker/image_spec.rb
@@ -269,6 +269,17 @@ describe Docker::Image do
     end
   end
 
+  describe '#save_stream' do
+    let(:image) { Docker::Image.get('busybox') }
+    let(:block) { proc { |chunk| puts chunk } }
+
+    it 'calls the class method' do
+      expect(Docker::Image).to receive(:save_stream)
+        .with(image.id, instance_of(Hash), instance_of(Docker::Connection))
+      image.save_stream(:chunk_size => 1024 * 1024, &block)
+    end
+  end
+
   describe '#load' do
     include_context "local paths"
     let(:file) { File.join(project_dir, 'spec', 'fixtures', 'load.tar') }
@@ -395,6 +406,24 @@ describe Docker::Image do
         raw = Docker::Image.save('swipely/base')
         expect(raw).to_not be_nil
       end
+    end
+  end
+
+  describe '.save_stream' do
+    let(:image) { 'busybox:latest' }
+    let(:expected) do
+      Docker.connection.get(
+        '/images/get',
+        'names' => URI.encode(image)
+      )
+    end
+    let(:actual) { '' }
+
+    it 'yields each chunk of the image' do
+      Docker::Image.save_stream(image) do |chunk|
+        actual << chunk.to_s
+      end
+      expect(actual).to eq(expected)
     end
   end
 


### PR DESCRIPTION
@tlunter Add Docker::Image.save_stream

This method allows the payload one or more Docker images to be streamed into a block.
Docker::Image.save_stream is now used to implement Docker::Image.save to keep the class DRY.