### PR TITLE
Allow image load to accept an io

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ require 'docker'
 Docker.version
 # => { 'Version' => '0.5.2', 'GoVersion' => 'go1.1' }
 
-# docker command for reference: docker info 
+# docker command for reference: docker info
 Docker.info
 # => { "Debug" => false, "Containers" => 187, "Images" => 196, "NFd" => 10, "NGoroutines" => 9, "MemoryLimit" => true }
 
@@ -244,6 +244,16 @@ Docker::Image.get('df4f1bdecf40')
 # Check if an image with a given id exists on the server.
 Docker::Image.exist?('ef723dcdac09')
 # => true
+
+# Load an image from the file system
+Docker::Image.load('./my-image.tar')
+# => ""
+
+# An IO object may also be specified for loading
+File.open('./my-image.tar', 'rb') do |file|
+  Docker::Image.load(file)
+end
+# => ""
 
 # Export multiple images to a single tarball
 # docker command for reference: docker save my_image1 my_image2:not_latest > my_export.tar

--- a/lib/docker/image.rb
+++ b/lib/docker/image.rb
@@ -171,14 +171,14 @@ class Docker::Image
     # Load a tar Image
     def load(tar, opts = {}, conn = Docker.connection, creds = nil, &block)
        headers = build_headers(creds)
+       io = tar.is_a?(String) ? File.open(tar, 'rb') : tar
        body = ""
-       f = File.open(tar,'rb')
        conn.post(
          '/images/load',
          opts,
          :headers => headers,
          :response_block => response_block(body, &block)
-       ) { f.read(Excon.defaults[:chunk_size]).to_s }
+       ) { io.read(Excon.defaults[:chunk_size]).to_s }
     end
 
     # Check if an image exists.

--- a/spec/docker/image_spec.rb
+++ b/spec/docker/image_spec.rb
@@ -280,17 +280,6 @@ describe Docker::Image do
     end
   end
 
-  describe '#load' do
-    include_context "local paths"
-    let(:file) { File.join(project_dir, 'spec', 'fixtures', 'load.tar') }
-    context 'test image upload' do
-      it 'load tianon/true image' do
-        result = Docker::Image.load(file)
-        expect(result).to eq("")
-      end
-    end
-  end
-
   describe '#refresh!' do
     let(:image) { Docker::Image.create('fromImage' => 'debian:wheezy') }
 
@@ -308,6 +297,29 @@ describe Docker::Image do
 
       it 'updates using the provided connection' do
         image.refresh!
+      end
+    end
+  end
+
+  describe '.load' do
+    include_context "local paths"
+    let(:file) { File.join(project_dir, 'spec', 'fixtures', 'load.tar') }
+
+    context 'when the argument is a String' do
+      it 'loads tianon/true image from the file system' do
+        result = Docker::Image.load(file)
+        expect(result).to eq("")
+      end
+    end
+
+    context 'when the argument is an IO' do
+      let(:io) { File.open(file) }
+
+      after { io.close }
+
+      it 'loads tinan/true image from the IO' do
+        result = Docker::Image.load(io)
+        expect(result).to eq("")
       end
     end
   end


### PR DESCRIPTION
@tlunter 

Allow `Docker::Image.load` to accept an `IO` object.