### PR TITLE
Bump Docker API version to 1.22

### DIFF
--- a/lib/docker/version.rb
+++ b/lib/docker/version.rb
@@ -3,5 +3,5 @@ module Docker
   VERSION = '1.28.0'
 
   # The version of the compatible Docker remote API.
-  API_VERSION = '1.16'
+  API_VERSION = '1.22'
 end


### PR DESCRIPTION
I've run the specs against [Docker API 1.22](https://docs.docker.com/engine/reference/api/docker_remote_api_v1.22/) and they all pass, besides 2 that are failing due to authentication problems (even with the old version). Could we bump `API_VERSION` to _1.22_?