### PR TITLE
trying to preserve file permissions from host when using insert_local

### DIFF
--- a/lib/docker/util.rb
+++ b/lib/docker/util.rb
@@ -119,8 +119,12 @@ module Docker::Util
   def create_tar(hash = {})
     output = StringIO.new
     Gem::Package::TarWriter.new(output) do |tar|
-      hash.each do |file_name, input|
-        tar.add_file(file_name, 0640) { |tar_file| tar_file.write(input) }
+      hash.each do |file_name, file_details|
+        permissions = file_details.is_a?(Hash) ? file_details[:permissions] : 0640
+        tar.add_file(file_name, permissions) do |tar_file|
+          content = file_details.is_a?(Hash) ? file_details[:content] : file_details
+          tar_file.write(content)
+        end
       end
     end
     output.tap(&:rewind).string
@@ -201,13 +205,24 @@ module Docker::Util
       basename = File.basename(local_path)
       if File.directory?(local_path)
         tar = create_dir_tar(local_path)
-        file_hash[basename] = tar.read
+        file_hash[basename] = {
+          content: tar.read,
+          permissions: filesystem_permissions(local_path)
+        }
         tar.close
         FileUtils.rm(tar.path)
       else
-        file_hash[basename] = File.read(local_path)
+        file_hash[basename] = {
+          content: File.read(local_path),
+          permissions: filesystem_permissions(local_path)
+        }
       end
     end
+  end
+
+  def filesystem_permissions(path)
+    mode = sprintf("%o", File.stat(path).mode)
+    mode[(mode.length - 3)...mode.length].to_i(8)
   end
 
   def build_auth_header(credentials)

--- a/spec/docker/util_spec.rb
+++ b/spec/docker/util_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'tempfile'
 
 describe Docker::Util do
   subject { described_class }
@@ -151,4 +152,19 @@ describe Docker::Util do
       end
     end
   end
+
+  describe '.filesystem_permissions' do
+    it 'returns the permissions on a file' do
+      file = Tempfile.new('test_file')
+      file.close
+      expected_permissions = 0600
+      File.chmod(expected_permissions, file.path)
+
+      actual_permissions = subject.filesystem_permissions(file.path)
+
+      file.unlink
+      expect(actual_permissions).to eql(expected_permissions)
+    end
+  end
+
 end


### PR DESCRIPTION
Reading the file permissions on the host and setting the same permissions when copying the files across to the image. 