### PR TITLE
Support new fields in docker event api

### DIFF
--- a/spec/docker/event_spec.rb
+++ b/spec/docker/event_spec.rb
@@ -1,21 +1,62 @@
 require 'spec_helper'
 
 describe Docker::Event do
-  describe "#to_s" do
-    subject { described_class.new(status, id, from, time) }
-
-    let(:status) { "start" }
-    let(:id) { "398c9f77b5d2" }
-    let(:from) { "debian:wheezy" }
-    let(:time) { 1381956164 }
-
-    let(:expected_string) {
-      "Docker::Event { :status => #{status}, :id => #{id}, "\
-      ":from => #{from}, :time => #{time.to_s} }"
+  let(:api_response) do
+    {
+      'Action' => 'start',
+      'Actor' => {
+        'Attributes' => {
+          'image' => 'tianon/true',
+          'name' => 'true-dat'
+        },
+        'ID' => 'bb2c783a32330b726f18d1eb44d80c899ef45771b4f939326e0fefcfc7e05db8'
+      },
+      'Type' => 'container',
+      'from' => 'tianon/true',
+      'id' => 'bb2c783a32330b726f18d1eb44d80c899ef45771b4f939326e0fefcfc7e05db8',
+      'status' => 'start',
+      'time' => 1461083270,
+      'timeNano' => 1461083270652069004
     }
+  end
 
-    it "equals the expected string" do
-      expect(subject.to_s).to eq(expected_string)
+  describe "#to_s" do
+    context 'with an old event' do
+      let(:event) do
+        described_class.new(
+          status: status,
+          id: id,
+          from: from,
+          time: time
+        )
+      end
+
+      let(:status) { "start" }
+      let(:id) { "398c9f77b5d2" }
+      let(:from) { "debian:wheezy" }
+      let(:time) { 1381956164 }
+
+      let(:expected_string) {
+        "Docker::Event { #{time} #{status} #{id} (from=#{from}) }"
+      }
+
+      it "equals the expected string" do
+        expect(event.to_s).to eq(expected_string)
+      end
+    end
+
+    context 'with a new event' do
+      let(:event) { described_class.new(api_response) }
+
+      let(:expected_string) do
+        'Docker::Event { 1461083270652069004 container start '\
+        'bb2c783a32330b726f18d1eb44d80c899ef45771b4f939326e0fefcfc7e05db8 '\
+        '(image=tianon/true, name=true-dat) }'
+      end
+
+      it 'equals the expected string' do
+        expect(event.to_s).to eq(expected_string)
+      end
     end
   end
 
@@ -68,22 +109,38 @@ describe Docker::Event do
   end
 
   describe ".new_event" do
-    subject { Docker::Event.new_event(response_body, nil, nil) }
-    let(:status) { "start" }
-    let(:id) { "398c9f77b5d2" }
-    let(:from) { "debian:wheezy" }
-    let(:time) { 1381956164 }
-    let(:response_body) {
-      "{\"status\":\"#{status}\",\"id\":\"#{id}\""\
-      ",\"from\":\"#{from}\",\"time\":#{time}}"
-    }
+    context 'with an old api response' do
+      let(:event) { Docker::Event.new_event(response_body, nil, nil) }
+      let(:status) { "start" }
+      let(:id) { "398c9f77b5d2" }
+      let(:from) { "debian:wheezy" }
+      let(:time) { 1381956164 }
+      let(:response_body) {
+        "{\"status\":\"#{status}\",\"id\":\"#{id}\""\
+        ",\"from\":\"#{from}\",\"time\":#{time}}"
+      }
 
-    it "returns a Docker::Event" do
-      expect(subject).to be_kind_of(Docker::Event)
-      expect(subject.status).to eq(status)
-      expect(subject.id).to eq(id)
-      expect(subject.from).to eq(from)
-      expect(subject.time).to eq(time)
+      it "returns a Docker::Event" do
+        expect(event).to be_kind_of(Docker::Event)
+        expect(event.status).to eq(status)
+        expect(event.id).to eq(id)
+        expect(event.from).to eq(from)
+        expect(event.time).to eq(time)
+      end
+    end
+
+    context 'with a new api response' do
+      let(:event) { Docker::Event.new_event(api_response.to_json, nil, nil) }
+
+      it 'returns a Docker::Event' do
+        expect(event).to be_kind_of(Docker::Event)
+        expect(event.type).to eq('container')
+        expect(event.action).to eq('start')
+        expect(event.actor.id).to eq('bb2c783a32330b726f18d1eb44d80c899ef45771b4f939326e0fefcfc7e05db8')
+        expect(event.actor.attributes).to eq('image' => 'tianon/true', 'name' => 'true-dat')
+        expect(event.time).to eq 1461083270
+        expect(event.time_nano).to eq 1461083270652069004
+      end
     end
   end
 end


### PR DESCRIPTION
This PR pulls in support for the action/actor based fields in the docker events api.  The format for the events api can be found at https://github.com/docker/engine-api/blob/master/types/events/events.go.  I kept support for the older format so this shouldn’t be a breaking change.