### PR TITLE
Matching new regex in extract_id for image builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - 2.0
   - 1.9.3
 env:
+  - DOCKER_VERSION=1.11.1
   - DOCKER_VERSION=1.10.3
   - DOCKER_VERSION=1.9.1
   - DOCKER_VERSION=1.8.2

--- a/lib/docker/util.rb
+++ b/lib/docker/util.rb
@@ -185,6 +185,8 @@ module Docker::Util
     body.lines.reverse_each do |line|
       if (id = line.match(/Successfully built ([a-f0-9]+)/)) && !id[1].empty?
         return id[1]
+      elsif (id = line.match(/sha256:([a-f0-9]+)/)) && !id[1].empty?
+        return id[1]
       end
     end
     raise UnexpectedResponseError, "Couldn't find id: #{body}"


### PR DESCRIPTION
Image building is broken on (at least) 1.11.1
This patch matches the new output in extract_id
