### PR TITLE
Fix Docker::Util.extract_id not prefixing `sha256:` (Docker >= 1.11)

### DIFF
--- a/lib/docker/util.rb
+++ b/lib/docker/util.rb
@@ -184,7 +184,7 @@ module Docker::Util
   def extract_id(body)
     body.lines.reverse_each do |line|
       if (id = line.match(/Successfully built ([a-f0-9]+)/)) && !id[1].empty?
-        return id[1]
+        return "sha256:#{id[1]}"
       end
     end
     raise UnexpectedResponseError, "Couldn't find id: #{body}"


### PR DESCRIPTION
Hello,

In the latest version, Docker decided to change the `/images/(name)/` endpoint. According to the Google Group, this change is intentational: https://groups.google.com/forum/#!topic/docker-dev/jBgZIFVrqZI

`(name)` is now one of:

* The human readable name of the image OR
* The image id (or short id) *prefixed* with `sha256:` like this: `sha256:0123456789abcdef`
* *Before* it was possible to also use just the image id

The issue within docker-api was `Docker::Util.extract_id` missing the prefix. This caused `Docker::Image.build_from_tar` to fail as the just created docker image wasn't found anymore.

This seems to work on Docker 1.10.3 too, can't tell for earlier versions.

Greetings,
Stefan