### PR TITLE
add the :wait parameter to container.exec

### DIFF
--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -59,6 +59,7 @@ class Docker::Container
     stdin = opts.delete(:stdin)
     stdout = opts.delete(:stdout) || !detach
     stderr = opts.delete(:stderr) || !detach
+    wait = opts.delete(:wait)
 
     # Create Exec Instance
     instance = Docker::Exec.create(
@@ -77,7 +78,8 @@ class Docker::Container
     start_opts = {
       :tty => tty,
       :stdin => stdin,
-      :detach => detach
+      :detach => detach,
+      :wait => wait
     }
 
     if detach


### PR DESCRIPTION
add the `:wait` parameter when call `exec.start!`