### PR TITLE
Fix excon errors namespace for excon >= 0.50

### DIFF
--- a/docker-api.gemspec
+++ b/docker-api.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.name          = "docker-api"
   gem.require_paths = %w{lib}
   gem.version       = Docker::VERSION
-  gem.add_dependency 'excon', '>= 0.38.0'
+  gem.add_dependency 'excon', '>= 0.50.0'
   gem.add_dependency 'json'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec', '~> 3.0'

--- a/lib/docker/connection.rb
+++ b/lib/docker/connection.rb
@@ -38,17 +38,17 @@ class Docker::Connection
     request = compile_request_params(*args, &block)
     log_request(request)
     resource.request(request).body
-  rescue Excon::Errors::BadRequest => ex
+  rescue Excon::Error::BadRequest => ex
     raise ClientError, ex.response.body
-  rescue Excon::Errors::Unauthorized => ex
+  rescue Excon::Error::Unauthorized => ex
     raise UnauthorizedError, ex.response.body
-  rescue Excon::Errors::NotFound => ex
+  rescue Excon::Error::NotFound => ex
     raise NotFoundError, ex.response.body
-  rescue Excon::Errors::Conflict => ex
+  rescue Excon::Error::Conflict => ex
     raise ConflictError, ex.response.body
-  rescue Excon::Errors::InternalServerError => ex
+  rescue Excon::Error::InternalServerError => ex
     raise ServerError, ex.response.body
-  rescue Excon::Errors::Timeout => ex
+  rescue Excon::Error::Timeout => ex
     raise TimeoutError, ex.message
   end
 


### PR DESCRIPTION
Excon changes errors namespace from Excon::Errors to Excon::Error since
version 0.50.x