### PR TITLE
Use value from info hash when there is a clash in key.

### DIFF
--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -11,7 +11,7 @@ class Docker::Container
     }
 
     info.merge!(self.json)
-    other && info.merge!(other.info)
+    other && info.merge!(other.info) { |key, info_value, other_value| info_value }
     self
   end
 


### PR DESCRIPTION
info has the detailed container information, rather than the more
abbreviated version from other.

Fixes #416 