### PR TITLE
support go 1.6 and docker-engine 1.12

### DIFF
--- a/lib/docker/connection.rb
+++ b/lib/docker/connection.rb
@@ -76,6 +76,7 @@ private
     query ||= {}
     opts ||= {}
     headers = opts.delete(:headers) || {}
+    headers['Host'] = "" if url == "unix:///" && !headers.key?('Host')
     content_type = opts[:body].nil? ?  'text/plain' : 'application/json'
     user_agent = "Swipely/Docker-API #{Docker::VERSION}"
     {
@@ -83,7 +84,7 @@ private
       :path          => "/v#{Docker::API_VERSION}#{path}",
       :query         => query,
       :headers       => { 'Content-Type' => content_type,
-                          'User-Agent'   => user_agent,
+                          'User-Agent'   => user_agent
                         }.merge(headers),
       :expects       => (200..204).to_a << 304,
       :idempotent    => http_method == :get,


### PR DESCRIPTION
Sorry to steal your commit @gouketsu . But we ran into this problem as well and your patch seems to fix it. Can we consider getting this merged into master? 

> docker-engine 1.12 now use go 1.6.
> go 1.6 implements the check of the Host field in the header and as / is not a valid byte for the Host, all request are rejected. As excon add in the Host if it's not defined the socket path we need to force the host as empty in this case to avoid the issue