### PR TITLE
Docker machine integration

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,10 +5,13 @@ require 'rake'
 require 'docker'
 require 'rspec/core/rake_task'
 require 'cane/rake_task'
+require 'docker_machine'
 
 
 desc 'Run the full test suite from scratch'
-task :default => [:unpack, :rspec, :quality]
+default = ['docker_machine:eval_env', :unpack, :rspec, :quality]
+default.shift if ENV['TRAVIS'] == 'true'
+task :default => default
 
 RSpec::Core::RakeTask.new do |t|
   t.pattern = 'spec/**/*_spec.rb'
@@ -20,8 +23,17 @@ end
 
 desc 'Download the necessary base images'
 task :unpack do
-  %w( swipely/base registry busybox tianon/true debian:wheezy ).each do |image|
-    system "docker pull #{image}"
+  %w(
+    swipely/base:latest
+    tianon/true:latest
+    debian:wheezy
+    registry:latest
+    busybox:latest
+  ).each do |image|
+    # doing this instead of #system because need it to work against a
+    # docker-machine if we use that.
+    puts "Pulling #{image}"
+    Docker::Image.create 'fromImage' => image
   end
 end
 
@@ -52,3 +64,86 @@ image 'ubuntu:13.10' do
   image = Docker::Image.create('fromImage' => 'ubuntu', 'tag' => '13.10')
   puts "Pulled ubuntu:13.10, image id: #{image.id}"
 end
+
+desc 'Used to setup docker-machines for test suite.'
+namespace :docker_machine do
+
+  def docker_version
+    ENV['DOCKER_VERSION'] || Docker.version['Version'] || 'unknown'
+  end
+
+  def name number
+    "docker-api-#{docker_version}-node-#{number}"
+  end
+
+  def no_docker_machine?
+    ENV['DOCKER_API_NO_DOCKER_MACHINE'] == 'true'
+  end
+
+  desc 'Check if docker-machine is installed.'
+  task :check do
+    unless no_docker_machine? || system('which', 'docker-machine')
+      warn "docker-machine is not installed. Consider setting it up in order "\
+        "for the test suite to be more robust. Refer to "\
+        "https://docs.docker.com/machine/install-machine/ for installation "\
+        "instructions."
+      ENV['DOCKER_API_NO_DOCKER_MACHINE'] = 'true'
+      puts 'Sleeping to allow time to read above...'
+      sleep 8
+    end
+  end
+
+  desc 'Remove docker-machines'
+  task :remove => :check do
+    unless no_docker_machine?
+      dm = DockerMachine.new
+      2.times do |i|
+        begin
+          dm.call "rm -f #{name i}", stream_logs: true
+        rescue DockerMachine::CLIError => err
+          p err
+        end
+      end
+    end
+  end
+
+  desc 'Create 2 docker machines for testing. 2 so we can do swarm testing.'\
+         "\nThis is opionated and only creates virtualbox VMs."
+  task :create_or_start => :check do
+    unless no_docker_machine?
+      dm = DockerMachine.new
+      2.times do |i|
+        begin
+          dm.call "status #{name i}"
+
+          case dm.out
+          when /stopped/i
+            dm.call "start #{name i}", stream_logs: true
+          end
+
+          puts "#{name i} is #{dm.out}"
+        rescue DockerMachine::CLIError => err
+          case dm.err
+          when /does not exist/
+            cmd = "create --driver virtualbox --virtualbox-boot2docker-url "\
+              "https://github.com/boot2docker/boot2docker/releases/download/v#{docker_version}/boot2docker.iso "\
+              "#{name i}"
+            dm.call cmd, stream_logs: true
+          end
+        end
+      end
+    end
+  end
+
+  desc 'Eval the docker-machine into runtime.'
+  task :eval_env => :create_or_start do
+    unless no_docker_machine?
+      dm = DockerMachine.new
+      dm.call "env #{name 0}"
+      env_vars = dm.out.scan /export\s+(\S+)=(\S+)/
+			env_vars.each { |v| ENV[v.first] = v.last.gsub /\A['"]|['"]\Z/, '' }
+      p Docker.options
+    end
+  end
+
+end # docker_machine namespace

--- a/TESTING.md
+++ b/TESTING.md
@@ -4,7 +4,7 @@ To develop on this gem, you must the following installed:
 ```shell
 $ gem install bundler
 ```
-* Docker v1.3.1 or greater
+* Docker >= v1.3.1 or docker-machine
 
 
 
@@ -28,22 +28,32 @@ $ git checkout -b my_bug_fix
 7. Assuming the tests pass, open a Pull Request on Github.
 
 # Using Rakefile Commands
-This repository comes with five Rake commands to assist in your testing of the code.
+This repository comes with Rake commands to assist in your testing of the code.
 
-## `rake rspec`
-This command will run Rspec tests normally on your local system. You must have all the required base images pulled.
+Run `bundle exec rake -D` to see helpful output on what these tasks do.
 
-## `rake quality`
-This command runs a code quality threshold checker to hinder bad code.
-
-## `rake unpack`
-Pulls down all the required base images for testing.
 
 ### Setting Up Environment Variables
-Certain Rspec tests will require your credentials to the Docker Hub. If you do not have a Docker Hub account, you can sign up for one [here](https://hub.docker.com/account/signup/). To avoid hard-coding credentials into the code the test suite leverages three Environment Variables: `DOCKER_API_USER`, `DOCKER_API_PASS`, and `DOCKER_API_EMAIL`. You will need to configure your work environment (shell profile, IDE, etc) with these values in order to successfully run certain tests.
+Certain Rspec tests will require your credentials to the Docker Hub. If you do
+not have a Docker Hub account, you can sign up for one
+[here](https://hub.docker.com/account/signup/). To avoid hard-coding
+credentials into the code the test suite leverages three Environment Variables:
+`DOCKER_API_USER`, `DOCKER_API_PASS`, and `DOCKER_API_EMAIL`. You will need to
+configure your work environment (shell profile, IDE, etc) with these values in
+order to successfully run certain tests.
 
 ```shell
 export DOCKER_API_USER='your_docker_hub_user'
 export DOCKER_API_PASS='your_docker_hub_password'
 export DOCKER_API_EMAIL='your_docker_hub_email_address'
 ```
+
+#### Docker version
+If you have Docker installed and docker-machine installed, the test suite will
+use your installed version of Docker to determine the version of the
+docker-machine to install. If you do not have Docker installed or want to test
+against another version of Docker, then you may use the ENV variable
+`DOCKER_VERSION` set to a valid release number of a boot2docker image found:
+https://github.com/boot2docker/boot2docker/releases E.g. `rake
+DOCKER_VERSION=1.11.1`. Refer to the Rakefile namespace docker_machine for more
+details on how this functions.

--- a/docker-api.gemspec
+++ b/docker-api.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'webmock'
   # > 1.3.4 doesn't support ruby 1.9.2
   gem.add_development_dependency 'parallel', '1.3.3'
+  gem.add_development_dependency 'docker_machine', '0.1.0'
 end


### PR DESCRIPTION
This PR aims to integrate docker-machine to ease local testing of docker-api. It does this by using a (very) lightweight gem called 'docker_machine' to talk to the `docker-machine` cli, sets up a docker-machine VM, evaluates the VMs docker config bits into the runtime's `ENV`, and runs the test suite against that VM. This has been tested to be working with `bundle exec rake DOCKER_VERSION=1.11.1`.

I am unsure if this is the best approach to make docker-api talk to the docker-machine and I am open to other approaches if they would fit better into how docker-api works.

I would like this to be merged sooner rather than later so that I may use it for my docker 1.12.0 updates I am doing for docker-api.

Thanks in advance and please let me know any questions you may have.