### PR TITLE
Fix rake task when image has no repo tag

### DIFF
--- a/lib/docker/rake_task.rb
+++ b/lib/docker/rake_task.rb
@@ -11,7 +11,7 @@ class Docker::ImageTask < Rake::Task
   private
 
   def has_repo_tag?
-    images.any? { |image| image.info['RepoTags'].include?(repo_tag) }
+    images.any? { |image| image.info['RepoTags'] && image.info['RepoTags'].include?(repo_tag) }
   end
 
   def images


### PR DESCRIPTION
Make sure the rake task does not fail when an image does not have any
`RepoTag` (RepoTag is `nil`).

I have noticed this only once so far on a busy Jenkins slave with docker 1.12 but one images had no repo tag and was preventing my rake task to execute properly.