### PR TITLE
use actionable code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 *.swp
 *.gem
 Gemfile.lock
-coverage/
 .ruby-*

--- a/docker-api.gemspec
+++ b/docker-api.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec-its'
   gem.add_development_dependency 'cane'
   gem.add_development_dependency 'pry'
-  gem.add_development_dependency 'simplecov'
+  gem.add_development_dependency 'single_cov'
   gem.add_development_dependency 'webmock'
   gem.add_development_dependency 'parallel'
 end

--- a/lib/docker/event.rb
+++ b/lib/docker/event.rb
@@ -108,11 +108,7 @@ class Docker::Event
   end
 
   def to_s_actor_style
-    most_accurate_time = if !time_nano.nil?
-                           time_nano
-                         elsif !time.nil?
-                           time
-                         end
+    most_accurate_time = time_nano || time
 
     attributes = []
     actor.attributes.each do |attribute, value|

--- a/spec/cov_spec.rb
+++ b/spec/cov_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+SingleCov.not_covered!
+
+describe "Coverage" do
+  it "has coverage for all tests" do
+    SingleCov.assert_used
+  end
+
+  it "has tests for all files" do
+    SingleCov.assert_tested untested: %w[
+      lib/docker/base.rb
+      lib/docker/error.rb
+      lib/docker/messages_stack.rb
+      lib/docker/rake_task.rb
+      lib/docker/version.rb
+      lib/docker-api.rb
+      lib/excon/middlewares/hijack.rb
+    ]
+  end
+end

--- a/spec/docker/connection_spec.rb
+++ b/spec/docker/connection_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+SingleCov.covered! uncovered: 7
+
 describe Docker::Connection do
   subject { described_class.new('http://localhost:4243', {}) }
 

--- a/spec/docker/container_spec.rb
+++ b/spec/docker/container_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+SingleCov.covered! uncovered: 1
+
 describe Docker::Container do
   describe '#to_s' do
     subject {
@@ -215,6 +217,11 @@ describe Docker::Container do
       expect(top).to be_a Array
       expect(top).to_not be_empty
       expect(top.first.keys).to include('PID')
+    end
+
+    it 'returns nothing when Processes were not returned due to an error' do
+      expect(Docker::Util).to receive(:parse_json).and_return({})
+      expect(top).to eq []
     end
   end
 

--- a/spec/docker/event_spec.rb
+++ b/spec/docker/event_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+SingleCov.covered!
+
 describe Docker::Event do
   let(:api_response) do
     {

--- a/spec/docker/exec_spec.rb
+++ b/spec/docker/exec_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+SingleCov.covered! uncovered: 4
+
 describe Docker::Exec do
   let(:container) {
     Docker::Container.create(

--- a/spec/docker/image_spec.rb
+++ b/spec/docker/image_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+SingleCov.covered! uncovered: 2
+
 describe Docker::Image do
   describe '#to_s' do
     subject { described_class.new(Docker.connection, info) }
@@ -21,7 +23,6 @@ describe Docker::Image do
   end
 
   describe '#remove' do
-
     context 'when no name is given' do
       let(:id) { subject.id }
       subject { described_class.create('fromImage' => 'busybox:latest') }

--- a/spec/docker/messages_spec.rb
+++ b/spec/docker/messages_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+SingleCov.covered! uncovered: 3
+
 describe Docker::Messages do
   shared_examples_for "two equal messages" do
     it "has the same messages as we expect" do

--- a/spec/docker/messages_stack.rb
+++ b/spec/docker/messages_stack.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
-describe Docker::MessagesStack do
+SingleCov.covered!
 
+describe Docker::MessagesStack do
   describe '#append' do
     context 'without limits' do |variable|
       it 'does not limit stack size by default' do

--- a/spec/docker/network_spec.rb
+++ b/spec/docker/network_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+SingleCov.covered! uncovered: 1
+
 describe Docker::Network, docker_1_9: true do
   let(:name) do |example|
     example.description.downcase.gsub('\s', '-')

--- a/spec/docker/util_spec.rb
+++ b/spec/docker/util_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 require 'tempfile'
 
+SingleCov.covered! uncovered: 71
+
 describe Docker::Util do
   subject { described_class }
 

--- a/spec/docker/volume_spec.rb
+++ b/spec/docker/volume_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+SingleCov.covered!
+
 # Volume requests are actually slow enough to occasionally not work
 # Use sleep statements to manage that
 describe Docker::Volume, :docker_1_9 do
@@ -42,5 +44,4 @@ describe Docker::Volume, :docker_1_9 do
       expect { volume.remove }.to change { Docker::Volume.all.length }.by(-1)
     end
   end
-
 end

--- a/spec/docker_spec.rb
+++ b/spec/docker_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+SingleCov.covered! uncovered: 2
+
 describe Docker do
   subject { Docker }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,14 @@ require 'bundler/setup'
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 
 require 'rspec/its'
-require 'simplecov'
+
+require 'single_cov'
+
+# avoid coverage failure from lower docker versions not running all tests
+if !ENV['DOCKER_VERSION'] || ENV['DOCKER_VERSION'] =~ /^1\.\d\d/
+  SingleCov.setup :rspec
+end
+
 require 'docker'
 
 ENV['DOCKER_API_USER']  ||= 'debbie_docker'
@@ -32,18 +39,18 @@ RSpec.configure do |config|
   config.include SpecHelpers
 
   case ENV['DOCKER_VERSION']
-  when /1\.6/
+  when /^1\.6/
     config.filter_run_excluding :docker_1_8 => true
     config.filter_run_excluding :docker_1_9 => true
     config.filter_run_excluding :docker_1_10 => true
-  when /1\.7/
+  when /^1\.7/
     config.filter_run_excluding :docker_1_8 => true
     config.filter_run_excluding :docker_1_9 => true
     config.filter_run_excluding :docker_1_10 => true
-  when /1\.8/
+  when /^1\.8/
     config.filter_run_excluding :docker_1_9 => true
     config.filter_run_excluding :docker_1_10 => true
-  when /1\.9/
+  when /^1\.9/
     config.filter_run_excluding :docker_1_10 => true
   end
 end


### PR DESCRIPTION
@tlunter 

before: useless noise and extra build time
```
Coverage report generated for RSpec to /Users/mgrosser/Code/tools/docker-api/coverage. 283 / 804 LOC (35.2%) covered.
-> 1.0s
```

after: clear info and no runtime overhead
```
lib/docker/util.rb new uncovered lines introduced (86 current vs 85 configured)
Lines missing coverage:
lib/docker/util.rb:15
-> 0.7s
```

I'll add this to all files if you want ... just a taste for now ...