### PR TITLE
Ensure stop & restart timeouts apply to Excon timeout

### DIFF
--- a/lib/docker/connection.rb
+++ b/lib/docker/connection.rb
@@ -87,7 +87,7 @@ private
                         }.merge(headers),
       :expects       => (200..204).to_a << 304,
       :idempotent    => http_method == :get,
-      :request_block => block
+      :request_block => block,
     }.merge(opts).reject { |_, v| v.nil? }
   end
 end

--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -99,7 +99,7 @@ class Docker::Container
   end
 
   # Attach to a container's standard streams / logs.
-  def attach(options = {}, &block)
+  def attach(options = {}, excon_params = {}, &block)
     stdin = options.delete(:stdin)
     tty   = options.delete(:tty)
 
@@ -108,8 +108,6 @@ class Docker::Container
     }.merge(options)
     # Creates list to store stdout and stderr messages
     msgs = Docker::Messages.new
-
-    excon_params = {}
 
     if stdin
       # If attaching to stdin, we must hijack the underlying TCP connection

--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -211,8 +211,18 @@ class Docker::Container
     define_method(:"#{method}!") do |opts = {}|
       timeout = opts.delete('timeout')
       query = {}
-      query['t'] = timeout if timeout
-      connection.post(path_for(method), query, :body => opts.to_json)
+      request_options = {
+        :body => opts.to_json
+      }
+      if timeout
+        query['t'] = timeout
+        # Ensure request does not timeout before Docker timeout
+        request_options.merge!(
+          read_timeout: timeout.to_i + 5,
+          write_timeout: timeout.to_i + 5
+        )
+      end
+      connection.post(path_for(method), query, request_options)
       self
     end
 

--- a/lib/docker/network.rb
+++ b/lib/docker/network.rb
@@ -2,10 +2,10 @@
 class Docker::Network
   include Docker::Base
 
-  def connect(container, opts = {})
+  def connect(container, opts = {}, body_opts = {})
     Docker::Util.parse_json(
       connection.post(path_for('connect'), opts,
-                      body: { container: container }.to_json)
+                      body: { container: container }.merge(body_opts).to_json)
     )
     reload
   end


### PR DESCRIPTION
Previously if a very long timeout was specified for a container, the HTTP request would likely time out before Docker responded. This ensures that the Docker timeout is hit before the HTTP request timeout configured in Excon