### PR TITLE
Update Excon version to use >= 0.46

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,7 +592,7 @@ end
 
 ## Known issues
 
-*   If the docker daemon is always responding to your requests with a 400 Bad Request when using UNIX sockets, verify you're running Excon version 0.46.0 or greater. [Link](https://github.com/swipely/docker-api/issues/381)
+*   Please check [Issues page](https://github.com/swipely/docker-api/issues)
 
 ## Not supported (yet)
 

--- a/docker-api.gemspec
+++ b/docker-api.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.name          = 'docker-api'
   gem.version       = Docker::VERSION
   gem.required_ruby_version = '>= 2.0.0'
-  gem.add_dependency 'excon', '>= 0.38.0'
+  gem.add_dependency 'excon', '>= 0.46'
   gem.add_dependency 'json'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
with older version of Excon, Docker responses with '400 Bad Request'

If you install this gem now, it's not a problem, but if you installed it before Excon=0.46
then docker-api gem installed excon and later updates don't require an update on excon.

Original issue: #381 

Related issue: https://github.com/excon/excon/issues/547