### PR TITLE
Adding missing opts parameter to Docker::Volume.create

### DIFF
--- a/lib/docker/volume.rb
+++ b/lib/docker/volume.rb
@@ -29,10 +29,9 @@ class Docker::Volume
     end
 
     # creates a volume with an arbitrary name
-    def create(name, conn = Docker.connection)
-      query = {}
-      query['name'] = name if name
-      resp = conn.post('/volumes/create', query, :body => query.to_json)
+    def create(name, opts = {}, conn = Docker.connection)
+      opts['Name'] = name
+      resp = conn.post('/volumes/create', {}, :body => opts.to_json)
       hash = Docker::Util.parse_json(resp) || {}
       new(conn, hash)
     end


### PR DESCRIPTION
At current, there's no way to pass any options during the creation of a docker volume. This pull requests fixes it.