### PR TITLE
Follow any redirects to enable swarm support

### DIFF
--- a/lib/docker.rb
+++ b/lib/docker.rb
@@ -14,6 +14,8 @@ require 'open-uri'
 require 'excon/middlewares/hijack'
 Excon.defaults[:middlewares].unshift Excon::Middleware::Hijack
 
+Excon.defaults[:middlewares] << Excon::Middleware::RedirectFollower
+
 # The top-level module for this gem. Its purpose is to hold global
 # configuration variables that are used as defaults in other classes.
 module Docker

--- a/lib/docker/connection.rb
+++ b/lib/docker/connection.rb
@@ -85,7 +85,7 @@ private
       :headers       => { 'Content-Type' => content_type,
                           'User-Agent'   => user_agent,
                         }.merge(headers),
-      :expects       => (200..204).to_a << 304,
+      :expects       => (200..204).to_a << 301 << 304,
       :idempotent    => http_method == :get,
       :request_block => block,
     }.merge(opts).reject { |_, v| v.nil? }


### PR DESCRIPTION
**CONTEXT**

When using docker via docker swarm, some commands will no longer return the expected 20X http status code, but instead give a 301 redirect, that the client is expected to follow.

The current version of docker-api (1.32.1), will not follow any redirects, and will raise an exception.

**THIS PR**

This PR will make docker-api automatically follow any HTTP redirects using the excon middleware RedirectFollower.

**TO REPRODUCE THE PROBLEM**

Setup a docker swarm. Then create a connection to it using the Docker class. Attempt to issue an request to a specific container, #kill

**TESTS**
I did not add tests for this PR, because you do not appear to be testing the connection class, beyond ensuring it conforms to Excon compliant output.