### PR TITLE
Allow to specify docker remote api version you want to use

### DIFF
--- a/lib/docker.rb
+++ b/lib/docker.rb
@@ -90,6 +90,14 @@ module Docker
     reset_connection!
   end
 
+  def api_version
+    options.fetch(:api_version, SUPPORTED_API_VERSION)
+  end
+
+  def api_version=(version)
+    options[:api_version] = version.to_s
+  end
+
   def connection
     @connection ||= Connection.new(url, options)
   end
@@ -132,14 +140,19 @@ module Docker
   # When the correct version of Docker is installed, returns true. Otherwise,
   # raises a VersionError.
   def validate_version!
+    !api_version.empty? &&
+      Gem::Version.new(api_version) < Gem::Version.new(SUPPORTED_API_VERSION) &&
+      raise(Docker::Error::VersionError)
+
     Docker.info
     true
-  rescue Docker::Error::DockerError
-    raise Docker::Error::VersionError, "Expected API Version: #{API_VERSION}"
+  rescue Docker::Error::DockerError, Docker::Error::VersionError
+    raise Docker::Error::VersionError, "Expected API Version: #{SUPPORTED_API_VERSION}"
   end
 
   module_function :default_socket_url, :env_url, :url, :url=, :env_options,
                   :options, :options=, :creds, :creds=, :logger, :logger=,
                   :connection, :reset!, :reset_connection!, :version, :info,
-                  :ping, :authenticate!, :validate_version!, :ssl_options
+                  :ping, :authenticate!, :validate_version!, :ssl_options,
+                  :api_version, :api_version=
 end

--- a/lib/docker/connection.rb
+++ b/lib/docker/connection.rb
@@ -76,11 +76,12 @@ private
     query ||= {}
     opts ||= {}
     headers = opts.delete(:headers) || {}
+    remote_api_version = Docker.api_version.empty? ? '' : "/v#{Docker.api_version}"
     content_type = opts[:body].nil? ?  'text/plain' : 'application/json'
     user_agent = "Swipely/Docker-API #{Docker::VERSION}"
     {
       :method        => http_method,
-      :path          => "/v#{Docker::API_VERSION}#{path}",
+      :path          => File.join(remote_api_version, path),
       :query         => query,
       :headers       => { 'Content-Type' => content_type,
                           'User-Agent'   => user_agent,

--- a/lib/docker/version.rb
+++ b/lib/docker/version.rb
@@ -3,5 +3,5 @@ module Docker
   VERSION = '1.33.1'
 
   # The version of the compatible Docker remote API.
-  API_VERSION = '1.16'
+  SUPPORTED_API_VERSION = '1.16'
 end

--- a/spec/docker/connection_spec.rb
+++ b/spec/docker/connection_spec.rb
@@ -75,10 +75,11 @@ describe Docker::Connection do
     let(:body) { rand(10000000) }
     let(:resource) { double(:resource) }
     let(:response) { double(:response, :body => body) }
+    let(:path_with_version) { "/v#{Docker::SUPPORTED_API_VERSION}#{path}" }
     let(:expected_hash) {
       {
         :method  => method,
-        :path    => "/v#{Docker::API_VERSION}#{path}",
+        :path    => path_with_version,
         :query   => query,
         :headers => { 'Content-Type' => 'text/plain',
                       'User-Agent'   => "Swipely/Docker-API #{Docker::VERSION}",
@@ -98,6 +99,17 @@ describe Docker::Connection do
 
     it 'sends #request to #resource with the compiled params' do
       expect(subject.request(method, path, query, options)).to eq body
+    end
+
+    context 'when api version is specified' do
+      before { Docker.api_version = '1.0.0' }
+      after { Docker.reset! }
+
+      let(:path_with_version) { "/v1.0.0#{path}" }
+
+      it 'sets api version it the :path option' do
+        expect(subject.request(method, path, query, options)).to eq body
+      end
     end
   end
 

--- a/spec/docker_spec.rb
+++ b/spec/docker_spec.rb
@@ -188,7 +188,7 @@ describe Docker do
   describe '#ping' do
     before { Docker.reset! }
 
-    let(:ping) { subject.ping}
+    let(:ping) { subject.ping }
 
     it 'returns the status as a String' do
       expect(ping).to eq('OK')
@@ -260,7 +260,7 @@ describe Docker do
 
       it 'raises a Version Error' do
         expect { subject.validate_version! }
-            .to raise_error(Docker::Error::VersionError)
+          .to raise_error(Docker::Error::VersionError)
       end
     end
 

--- a/spec/docker_spec.rb
+++ b/spec/docker_spec.rb
@@ -243,6 +243,16 @@ describe Docker do
   describe '#validate_version' do
     before { Docker.reset! }
 
+    context 'when specified version is not supported by the client' do
+      before { Docker.api_version = '0.0.1' }
+      after { Docker.reset! }
+
+      it 'raises a Version Error' do
+        expect { subject.validate_version! }
+          .to raise_error(Docker::Error::VersionError)
+      end
+    end
+
     context 'when a Docker Error is raised' do
       before do
         allow(Docker).to receive(:info).and_raise(Docker::Error::ClientError)


### PR DESCRIPTION
Hi,

Right now `Docker::API_VERSION` is hardcoded, so we cannot use the latest features of api.

For example, I have docker 1.12.5 installed (with api version 1.24 supported) and I was not able to get containers IPAddress when connected to user-defined docker bridge network.

I figured out that this feature (Show networks settings for each network when inspecting a container) was added in the [api version 1.21](https://docs.docker.com/engine/reference/api/docker_remote_api/#/v121-api-changes). But gems code using `1.16` version each request.

Actually it's not required to explicitly specify version to use. Here is what docker documentation says about using api versions:

```
The current version of the API is v1.24 which means calling /info is the same as calling /v1.24/info.
To call an older version of the API use /v1.23/info.
If a newer daemon is installed, new properties may be returned even when calling older versions of the API.
```

Since I would like to use the latest docker api version, I propose this pull request, where user may specify his docker remote api version.

Actually I thought, that it is better to use the latest api version by default (do not explicitly specify any versions), but some tests was failing. So I did not modify default behaviour.