### PR TITLE
services endpoints were started

### DIFF
--- a/lib/docker.rb
+++ b/lib/docker.rb
@@ -34,6 +34,7 @@ module Docker
   require 'docker/util'
   require 'docker/version'
   require 'docker/volume'
+  require 'docker/service'
   require 'docker/rake_task' if defined?(Rake::Task)
 
   def default_socket_url

--- a/lib/docker/service.rb
+++ b/lib/docker/service.rb
@@ -1,0 +1,47 @@
+# This class represents a Docker Service
+
+class Docker::Service
+  include Docker::Base
+
+  # refresh current Service
+  def refresh!(opts = {}, conn = Docker.connection)
+    resp = conn.get("/services/#{URI.encode(self.id)}", opts)
+    hash = Docker::Util.parse_json(resp) || {}
+    info.merge!(hash)
+    self
+  end
+
+  # destroy current Service
+  def delete!(opts = {}, conn = Docker.connection)
+    resp = conn.delete("/services/#{URI.encode(self.id)}", opts)
+    Docker::Util.parse_json(resp) || {}
+  end
+
+  # Get all Services
+  def self.all(opts = {}, conn = Docker.connection)
+    resp = conn.get('/services', opts)
+    hashes = Docker::Util.parse_json(resp) || []
+    hashes.map { |hash| new(conn, hash) }
+  end
+
+  # Create new Service
+  def self.create(opts = {}, conn = Docker.connection)
+    resp = conn.post('/services/create', {}, :body => opts.to_json)
+    hash = Docker::Util.parse_json(resp) || {}
+    new(conn, hash)
+  end
+
+  # get a Service
+  def self.get(id_or_name, opts = {}, conn = Docker.connection)
+    resp = conn.get("/services/#{URI.encode(id_or_name)}", opts)
+    hash = Docker::Util.parse_json(resp) || {}
+    new(conn, hash)
+  end
+
+  # TODO: create the "update" method
+  # according to this doc:
+  # https://docs.docker.com/engine/reference/api/docker_remote_api_v1.24/#/update-a-service
+
+  # TODO: create "ps" when it is available on the docker api
+  # https://docs.docker.com/engine/reference/commandline/service_ps
+end


### PR DESCRIPTION
Hi guys!
Just want to add a few important endpoints which are available in docker-engine since the version 1.12
Let me know any thoughts.

Also I have one question: why all the tests are so massive? They're running too long and I can't realize why even the docker is required! So, this app is just a simple REST API client, it should not testing the docker functionality! Imho strictly should not! Why not to write simple mock-objects of supposed responses? In this case it's possible to track the Docker API versions. Apologize if I'm missing something, just trying to understand what's going on.