### PR TITLE
`Image.create`: support the `tag` argument

### DIFF
--- a/lib/docker/image.rb
+++ b/lib/docker/image.rb
@@ -117,7 +117,10 @@ class Docker::Image
         :headers => headers,
         :response_block => response_block(body, &block)
         )
+      # NOTE: see associated tests for why we're looking at image#end_with?
       image = opts['fromImage'] || opts[:fromImage]
+      tag = opts['tag'] || opts[:tag]
+      image = "#{image}:#{tag}" if tag && !image.end_with?(":#{tag}")
       get(image, {}, conn)
     end
 

--- a/spec/docker/image_spec.rb
+++ b/spec/docker/image_spec.rb
@@ -383,6 +383,47 @@ describe Docker::Image do
       end
     end
 
+    context 'image with tag' do
+      it 'pulls the image (string arguments)' do
+        image = subject.create('fromImage' => 'busybox', 'tag' => 'uclibc')
+        image.refresh!
+        expect(image.info['RepoTags']).to include('busybox:uclibc')
+      end
+
+      it 'pulls the image (symbol arguments)' do
+        image = subject.create(fromImage: 'busybox', tag: 'uclibc')
+        image.refresh!
+        expect(image.info['RepoTags']).to include('busybox:uclibc')
+      end
+
+      it 'supports identical fromImage and tag', docker_1_10: true do
+        # This is here for backwards compatibility. docker-api used to
+        # complete ignore the "tag" argument, which Docker itself prioritizes
+        # over a tag found in fromImage, which meant that we had 3 scenarios:
+        #
+        # 1 fromImage does not include a tag, and the tag argument is provided
+        #   and isn't the default (i.e. "latest"): docker-api crashes looking
+        #   for fromImage when the image that was pulled is fromImage:tag (or
+        #   returns the wrong image if fromImage:latest exists)
+        # 2 fromImage does not a include a tag, and the tag argument is absent
+        #   or default (i.e. "latest"): docker-api finds the right image.
+        # 3 fromImage includes a tag, and the tag argument is absent: docker-api
+        #   also finds the right image.
+        # 4 fromImage includes a tag, and the tag argument is present: works if
+        #   the tag is the same in both.
+        #
+        # Adding support for the tag argument to fix 1 above means we'd break 4
+        # if we didn't explicitly handle the case where both tags are identical.
+        # This is what this test checks.
+        #
+        # Note that providing the tag inline in fromImage is only supported in
+        # Docker 1.10 and up.
+        image = subject.create(fromImage: 'busybox:uclibc', tag: 'uclibc')
+        image.refresh!
+        expect(image.info['RepoTags']).to include('busybox:uclibc')
+      end
+    end
+
     context 'with a block capturing create output' do
       let(:create_output) { "" }
       let(:block) { Proc.new { |chunk| create_output << chunk } }


### PR DESCRIPTION
When a `tag` argument is passed to `Image.create`, that argument needs
to be re-used when loading the image after it's pulled, otherwise trying
to get the image will either crash with a not found error, or return the
wrong image (depending on whether the `latest` tag exists locally for
the repository being pulled).

That part is pretty straightforward, but there are some edge cases when
the user is providing a tag with `fromImage` *and* `tag`.

It is probably desirable to throw an error in most cases: if the user is
confused and passing two different tags, `docker-api` probably shouldn't
venture a guess as to which one they *really* meant (although Docker
itself does assume they meant the one from `tag`). Here, this will fail
by trying to look for an image like `busybox:uclibc:glibc`, which Docker
won't find).

However, there is one case where not throwing an error is fine: when
`fromImage` and the `tag` represent the same tag. In this case,
appending the tag would cause an error (we'd be looking for e.g.
`busybox:uclibc:uclibc`), whereas just `get`'ing `image` would do the
right thing. So, I added an exception to not append the tag when that
tag is already present verbatim in the image.

---

A couple notes:

- one alternative to conditionally appending the suffix is to just throw an error when `fromImage` includes a tag and `tag` is present. This feels a little awkward though (there can be a colon in the repository URL for the port, so we'd essentially have to parse the entire repo url to make this work... which intuitively seems quite error-prone).
- `busybox` is a pretty small repo, but we could use `swipely/base` if it had some tags.

Cheers,