### PR TITLE
Fix ignored build errors when downloading images

### DIFF
--- a/lib/docker/util.rb
+++ b/lib/docker/util.rb
@@ -195,8 +195,6 @@ module Docker::Util
     body.lines.reverse_each do |line|
       if (id = line.match(/Successfully built ([a-f0-9]+)/)) && !id[1].empty?
         return id[1]
-      elsif (id = line.match(/sha256:([a-f0-9]+)/)) && !id[1].empty?
-        return id[1]
       end
     end
     raise UnexpectedResponseError, "Couldn't find id: #{body}"


### PR DESCRIPTION
### Description

When building an image, if it requires to download parent images and then the build fails, the error is ignored and it returns an invalid image id.

### Affected Versions

- `docker-api` gem from versions `1.29.0` to `1.33.2` (both included).

### How to Reproduce

A failing *Dockerfile* example:

```Dockerfile
FROM alpine
RUN apk add --update wrong-package-name
```

A small ruby example to build it:

```ruby
require 'docker'
image = Docker::Image.build_from_dir('.') { |v| puts v }
puts "BUILT IMAGE ID: #{image.id}"
```

Shell output:

```
$ docker --version
Docker version 1.11.1, build 5604cbe
$ docker rmi -f alpine:latest
$ ruby docker_ignore_build_error.rb 
{"stream":"Step 1 : FROM alpine\n"}
{"status":"Pulling from library/alpine","id":"latest"}
{"status":"Pulling fs layer","progressDetail":{},"id":"627beaf3eaaf"}
{"status":"Downloading","progressDetail":{"current":32768,"total":1905270},"progress":"[\u003e                                                  ] 32.77 kB/1.905 MB","id":"627beaf3eaaf"}
{"status":"Downloading","progressDetail":{"current":64639,"total":1905270},"progress":"[=\u003e                                                 ] 64.64 kB/1.905 MB","id":"627beaf3eaaf"}
[...]
{"status":"Extracting","progressDetail":{"current":1905270,"total":1905270},"progress":"[==================================================\u003e] 1.905 MB/1.905 MB","id":"627beaf3eaaf"}
{"status":"Pull complete","progressDetail":{},"id":"627beaf3eaaf"}
{"status":"Digest: sha256:58e1a1bb75db1b5a24a462dd5e2915277ea06438c3f105138f97eb53149673c4"}
{"status":"Status: Downloaded newer image for alpine:latest"}
{"stream":" ---\u003e 4a415e366388\n"}
{"stream":"Step 2 : RUN apk add --update wrong-package-name\n"}
{"stream":" ---\u003e Running in 660d22d0e61d\n"}
{"errorDetail":{"message":"Container command '/bin/sh' not found or does not exist."},"error":"Container command '/bin/sh' not found or does not exist."}
BUILT IMAGE ID: 58e1a1bb75db1b5a24a462dd5e2915277ea06438c3f105138f97eb53149673c4
```

As you can see, the build process has failed and it erroneously returns the image ID of the downloaded alpine image.

The next builds, that do not require to download alpine again, treat the error correctly:

```
$ docker images alpine
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
alpine              latest              4a415e366388        13 days ago         3.987 MB
$ ruby docker_ignore_build_error.rb 
{"stream":"Step 1 : FROM alpine\n"}
{"stream":" ---\u003e 4a415e366388\n"}
{"stream":"Step 2 : RUN apk add --update wrong-package-name\n"}
{"stream":" ---\u003e Running in 1d8bed6a1ce7\n"}
{"errorDetail":{"message":"Container command '/bin/sh' not found or does not exist."},"error":"Container command '/bin/sh' not found or does not exist."}
/home/dockertests/.rvm/gems/ruby-2.4.0@docker/gems/docker-api-1.33.2/lib/docker/util.rb:202:in `extract_id': Couldn't find  (Docker::Error::UnexpectedResponseError)
{"stream":" ---\u003e 4a415e366388\n"}
{"stream":"Step 2 : RUN apk add --update wrong-package-name\n"}
{"stream":" ---\u003e Running in 1d8bed6a1ce7\n"}
{"errorDetail":{"message":"Container command '/bin/sh' not found or does not exist."},"error":"Container command '/bin/sh' not found or does not exist."}
        from /home/dockertests/.rvm/gems/ruby-2.4.0@docker/gems/docker-api-1.33.2/lib/docker/image.rb:266:in `build_from_tar'
        from /home/dockertests/.rvm/gems/ruby-2.4.0@docker/gems/docker-api-1.33.2/lib/docker/image.rb:278:in `build_from_dir'
        from docker_ignore_build_error.rb:2:in `<main>'
```

### Tested Versions

I have tested this both with Docker version `1.11.1` (binary version from GitHub) and with the latest `1.13.1` release. I don't quite understand why this was required for version `1.11.1`. I have not been able to reproduce the problem described by @someara in the issue #402. Maybe I'm missing something.

### Related Issues

This reverts PR #402.