### PR TITLE
Allow passing in file permissions to container#store_file

### DIFF
--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -320,10 +320,17 @@ class Docker::Container
     end
   end
 
-  def store_file(path, file_content)
+  def store_file(path, file_content, file_permissions=nil)
+    file_details =
+      if file_permissions
+        { content: file_content, permissions: file_permissions }
+      else
+        file_content
+      end
+
     output_io = StringIO.new(
       Docker::Util.create_tar(
-        path => file_content
+        path => file_details
       )
     )
 


### PR DESCRIPTION
Enables us to pass in specific file permissions when storing a file, e.g.

```ruby
container.store_file('/test.rb', "puts 'hello world'", 0640)
```