### PR TITLE
Use correct Base 64 encoding for auth headers

### DIFF
--- a/lib/docker/util.rb
+++ b/lib/docker/util.rb
@@ -233,7 +233,7 @@ module Docker::Util
 
   def build_auth_header(credentials)
     credentials = credentials.to_json if credentials.is_a?(Hash)
-    encoded_creds = Base64.encode64(credentials).gsub(/\n/, '')
+    encoded_creds = Base64.urlsafe_encode64(credentials)
     {
       'X-Registry-Auth' => encoded_creds
     }
@@ -251,7 +251,7 @@ module Docker::Util
       }
     }.to_json
 
-    encoded_header = Base64.encode64(header).gsub(/\n/, '')
+    encoded_header = Base64.urlsafe_encode64(header)
 
     {
       'X-Registry-Config' => encoded_header

--- a/spec/docker/util_spec.rb
+++ b/spec/docker/util_spec.rb
@@ -159,7 +159,7 @@ describe Docker::Util do
       }
     }
     let(:credential_string) { credentials.to_json }
-    let(:encoded_creds) { Base64.encode64(credential_string).gsub(/\n/, '') }
+    let(:encoded_creds) { Base64.urlsafe_encode64(credential_string) }
     let(:expected_header) {
       {
         'X-Registry-Auth' => encoded_creds
@@ -178,6 +178,11 @@ describe Docker::Util do
           subject.build_auth_header(credential_string)
         ).to eq(expected_header)
       end
+    end
+
+    it 'does not contain newlines' do
+      h = subject.build_auth_header(credentials).fetch('X-Registry-Auth')
+      expect(h).not_to include("\n")
     end
   end
 
@@ -203,7 +208,7 @@ describe Docker::Util do
       }.to_json
     }
 
-    let(:encoded_creds) { Base64.encode64(credentials_object).gsub(/\n/, '') }
+    let(:encoded_creds) { Base64.urlsafe_encode64(credentials_object) }
     let(:expected_header) {
       {
         'X-Registry-Config' => encoded_creds
@@ -222,6 +227,11 @@ describe Docker::Util do
           subject.build_config_header(credentials.to_json)
         ).to eq(expected_header)
       end
+    end
+
+    it 'does not contain newlines' do
+      h = subject.build_config_header(credentials).fetch('X-Registry-Config')
+      expect(h).not_to include("\n")
     end
   end
 


### PR DESCRIPTION
Docker expects the X-Registry-Auth and X-Registry-Config headers to be
encoded using URL-safe Base 64 encoding (the latter is documented,
although the former isn't: https://github.com/moby/moby/issues/33434).

If an incorrect encoding is used, Docker will silently ignore the header
for pulls, and it may fail in other cases.