### PR TITLE
Make `Docker::Image.search` aware of credentials to search private repositories

### DIFF
--- a/lib/docker/image.rb
+++ b/lib/docker/image.rb
@@ -206,8 +206,14 @@ class Docker::Image
 
     # Given a query like `{ :term => 'sshd' }`, queries the Docker Registry for
     # a corresponding Image.
-    def search(query = {}, connection = Docker.connection)
-      body = connection.get('/images/search', query)
+    def search(query = {}, connection = Docker.connection, creds = nil)
+      credentials = creds.nil? ? Docker.creds : creds.to_json
+      headers = credentials && Docker::Util.build_auth_header(credentials) || {}
+      body = connection.get(
+        '/images/search',
+        query,
+        :headers => headers,
+      )
       hashes = Docker::Util.parse_json(body) || []
       hashes.map { |hash| new(connection, 'id' => hash['name']) }
     end


### PR DESCRIPTION
Fix #489

Note:
I guess it is little confusing. `.create` signature is `create(opts, creds, conn)`, but `.search` signature is `search(query, conn, creds)`. `creds` and `conn` are reversed between them. But it will be a breaking change if it is sorted. WDYT?