### PR TITLE
[BUG] Don't mutate opts on container.create

### DIFF
--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -332,9 +332,7 @@ class Docker::Container
 
   # Create a new Container.
   def self.create(opts = {}, conn = Docker.connection)
-    name = opts['name'] || opts[:name]
-    query = {}
-    query['name'] = name if name
+    query = opts.slice('name', :name)
     clean_opts = opts.reject {|key| ['name', :name].include?(key) }
     resp = conn.post('/containers/create', query, :body => clean_opts.to_json)
     hash = Docker::Util.parse_json(resp) || {}

--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -332,10 +332,11 @@ class Docker::Container
 
   # Create a new Container.
   def self.create(opts = {}, conn = Docker.connection)
-    name = opts.delete('name') || opts.delete(:name)
+    name = opts['name'] || opts[:name]
     query = {}
     query['name'] = name if name
-    resp = conn.post('/containers/create', query, :body => opts.to_json)
+    clean_opts = opts.reject {|key| ['name', :name].include?(key) }
+    resp = conn.post('/containers/create', query, :body => clean_opts.to_json)
     hash = Docker::Util.parse_json(resp) || {}
     new(conn, hash)
   end

--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -332,7 +332,7 @@ class Docker::Container
 
   # Create a new Container.
   def self.create(opts = {}, conn = Docker.connection)
-    query = opts.slice('name', :name)
+    query = opts.select {|key| ['name', :name].include?(key) }
     clean_opts = opts.reject {|key| ['name', :name].include?(key) }
     resp = conn.post('/containers/create', query, :body => clean_opts.to_json)
     hash = Docker::Util.parse_json(resp) || {}


### PR DESCRIPTION
The `container#create` method mutates the options you provide it which is not good. User passing in configuration objects will find them coming back mutated.

At first I just `.dup`'d the opts, but then a colleague pointed out that `.dup` is shallow. One way to ensure this doesn't happen elsewhere is to `.freeze` the options provided to these methods in the spec suite? That's how I found this bug in the first place.

This method in general seems a little clumsy, maybe other folks can suggest a more full refactor.