### PR TITLE
Allows to specify version of the Docker API to use

### DIFF
--- a/lib/docker.rb
+++ b/lib/docker.rb
@@ -19,7 +19,7 @@ Excon.defaults[:middlewares] << Excon::Middleware::RedirectFollower
 # The top-level module for this gem. Its purpose is to hold global
 # configuration variables that are used as defaults in other classes.
 module Docker
-  attr_accessor :creds, :logger
+  attr_accessor :creds, :logger, :api_version
 
   require 'docker/error'
   require 'docker/connection'
@@ -143,5 +143,6 @@ module Docker
   module_function :default_socket_url, :env_url, :url, :url=, :env_options,
                   :options, :options=, :creds, :creds=, :logger, :logger=,
                   :connection, :reset!, :reset_connection!, :version, :info,
-                  :ping, :authenticate!, :validate_version!, :ssl_options
+                  :ping, :authenticate!, :validate_version!, :ssl_options,
+                  :api_version, :api_version=
 end

--- a/lib/docker/connection.rb
+++ b/lib/docker/connection.rb
@@ -80,7 +80,7 @@ private
     user_agent = "Swipely/Docker-API #{Docker::VERSION}"
     {
       :method        => http_method,
-      :path          => "/v#{Docker::API_VERSION}#{path}",
+      :path          => "/v#{Docker.api_version || Docker::API_VERSION}#{path}",
       :query         => query,
       :headers       => { 'Content-Type' => content_type,
                           'User-Agent'   => user_agent,


### PR DESCRIPTION
It can be useful in some situations.

docker version
Client:
 Version:      17.06.0-ce
 API version:  1.30
 Go version:   go1.8.3
 Git commit:   02c1d87
 Built:        Fri Jun 23 21:23:31 2017
 OS/Arch:      linux/amd64

Server:
 Version:      17.06.0-ce
 API version:  1.30 (minimum version 1.12)
 Go version:   go1.8.3
 Git commit:   02c1d87
 Built:        Fri Jun 23 21:19:04 2017
 OS/Arch:      linux/amd64
 Experimental: false

```
Docker::Container.get(task).info['NetworkSettings']['Networks'] # => nil

Docker.api_version = '1.24'
Docker::Container.get(task).info['NetworkSettings']['Networks'] # =>
   {"consul_default"=>
     {"IPAMConfig"=>{"IPv4Address"=>"10.0.0.3"},
      "Links"=>nil,
      "Aliases"=>["a5dd68c1b5d5"],
      "NetworkID"=>"ng3pxiccxk5adwrctz6gog27l",
      "EndpointID"=>
       "ba7b0a5b9999ace86baf27ce6d7d414ca46c2e0f6e444c2e17fee29bf1d3979b",
      "Gateway"=>"",
      "IPAddress"=>"10.0.0.3",
      "IPPrefixLen"=>24,
      "IPv6Gateway"=>"",
      "GlobalIPv6Address"=>"",
      "GlobalIPv6PrefixLen"=>0,
      "MacAddress"=>"02:42:0a:00:00:03",
      "DriverOpts"=>nil},
    "ingress"=>
     {"IPAMConfig"=>{"IPv4Address"=>"10.255.0.4"},
      "Links"=>nil,
      "Aliases"=>["a5dd68c1b5d5"],
      "NetworkID"=>"vhtxc8io33wkoq43g6f96fqhx",
      "EndpointID"=>
       "f246a87ceca4b6f34964755a355b558d23f345434b3274089b68ef6b0ea6ae48",
      "Gateway"=>"",
      "IPAddress"=>"10.255.0.4",
      "IPPrefixLen"=>16,
      "IPv6Gateway"=>"",
      "GlobalIPv6Address"=>"",
      "GlobalIPv6PrefixLen"=>0,
      "MacAddress"=>"02:42:0a:ff:00:04",
      "DriverOpts"=>nil}}
```  