### PR TITLE
Add opts to image prune

### DIFF
--- a/lib/docker/image.rb
+++ b/lib/docker/image.rb
@@ -138,8 +138,8 @@ class Docker::Image
     alias_method :delete, :remove
 
     # Prune images
-    def prune(conn = Docker.connection)
-      conn.post("/images/prune", {})
+    def prune(opts = {}, conn = Docker.connection)
+      conn.post("/images/prune", opts)
     end
 
 


### PR DESCRIPTION
Allow options to be specified during image pruning, for example: 

`{filters: {dangling: ['false']}.to_json}`

Fixes #506 