### PR TITLE
Remove API version from request path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ rvm:
   - 2.1
   - 2.0
 env:
+  - DOCKER_VERSION=17.12.0~ce-0~ubuntu DOCKER_CE=1
+  - DOCKER_VERSION=17.09.1~ce-0~ubuntu DOCKER_CE=1
+  - DOCKER_VERSION=17.06.2~ce-0~ubuntu DOCKER_CE=1
   - DOCKER_VERSION=17.03.1~ce-0~ubuntu-trusty DOCKER_CE=1
   - DOCKER_VERSION=1.13.1-0~ubuntu-trusty
   - DOCKER_VERSION=1.12.3-0~trusty

--- a/lib/docker/connection.rb
+++ b/lib/docker/connection.rb
@@ -80,7 +80,7 @@ private
     user_agent = "Swipely/Docker-API #{Docker::VERSION}"
     {
       :method        => http_method,
-      :path          => "/v#{Docker::API_VERSION}#{path}",
+      :path          => path,
       :query         => query,
       :headers       => { 'Content-Type' => content_type,
                           'User-Agent'   => user_agent,

--- a/lib/docker/event.rb
+++ b/lib/docker/event.rb
@@ -29,7 +29,9 @@ class Docker::Event
 
     def stream(opts = {}, conn = Docker.connection, &block)
       conn.get('/events', opts, :response_block => lambda { |b, r, t|
-        block.call(new_event(b, r, t))
+        b.each_line do |line|
+          block.call(new_event(line, r, t))
+        end
       })
     end
 

--- a/spec/docker/connection_spec.rb
+++ b/spec/docker/connection_spec.rb
@@ -78,7 +78,7 @@ describe Docker::Connection do
     let(:expected_hash) {
       {
         :method  => method,
-        :path    => "/v#{Docker::API_VERSION}#{path}",
+        :path    => path,
         :query   => query,
         :headers => { 'Content-Type' => 'text/plain',
                       'User-Agent'   => "Swipely/Docker-API #{Docker::VERSION}",

--- a/spec/docker/container_spec.rb
+++ b/spec/docker/container_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-SingleCov.covered! uncovered: 1
+SingleCov.covered! uncovered: 3
 
 describe Docker::Container do
   describe '#to_s' do

--- a/spec/docker/container_spec.rb
+++ b/spec/docker/container_spec.rb
@@ -265,7 +265,7 @@ describe Docker::Container do
     end
   end
 
-  describe '#copy', docker_1_13: false do
+  describe '#copy', docker_1_12: false do
     let(:image) { Docker::Image.create('fromImage' => 'debian:wheezy') }
     subject { image.run('touch /test').tap { |c| c.wait } }
 

--- a/spec/docker/container_spec.rb
+++ b/spec/docker/container_spec.rb
@@ -85,7 +85,7 @@ describe Docker::Container do
 
   describe '#stats', :docker_1_9 do
     after(:each) do
-      subject.kill!
+      subject.wait
       subject.remove
     end
 
@@ -122,7 +122,7 @@ describe Docker::Container do
       it "returns after :read_timeout if the container is not running", :docker_old do
         called_count = 0
         subject.stats(read_timeout: 3) do |output|
-          called_count +=1
+          called_count += 1
         end
         expect(called_count).to eq 0
       end
@@ -204,10 +204,10 @@ describe Docker::Container do
 
     it "updates the container" do
       subject.refresh!
-      expect(subject.info.fetch("Config").fetch("CpuShares")).to eq 60000
+      expect(subject.info.fetch("HostConfig").fetch("CpuShares")).to eq 60000
       subject.update("CpuShares" => 50000)
       subject.refresh!
-      expect(subject.info.fetch("Config").fetch("CpuShares")).to eq 50000
+      expect(subject.info.fetch("HostConfig").fetch("CpuShares")).to eq 50000
     end
   end
 
@@ -265,7 +265,7 @@ describe Docker::Container do
     end
   end
 
-  describe '#copy' do
+  describe '#copy', docker_1_13: false do
     let(:image) { Docker::Image.create('fromImage' => 'debian:wheezy') }
     subject { image.run('touch /test').tap { |c| c.wait } }
 
@@ -510,12 +510,13 @@ describe Docker::Container do
       described_class.create(
         'Cmd' => %w[test -d /foo],
         'Image' => 'debian:wheezy',
-        'Volumes' => {'/foo' => {}}
+        'Volumes' => {'/foo' => {}},
+        'HostConfig' => { 'Binds' => ["/tmp:/foo"] }
       )
     }
     let(:all) { Docker::Container.all(all: true) }
 
-    before { subject.start('Binds' => ["/tmp:/foo"]) }
+    before { subject.start }
     after(:each) { subject.remove }
 
     it 'starts the container' do

--- a/spec/docker/image_spec.rb
+++ b/spec/docker/image_spec.rb
@@ -301,7 +301,7 @@ describe Docker::Image do
       after { container.remove }
 
       it 'returns 50' do
-        expect(container.json["Config"]["CpuShares"]).to eq 50
+        expect(container.json["HostConfig"]["CpuShares"]).to eq 50
       end
     end
   end
@@ -653,9 +653,14 @@ describe Docker::Image do
   describe '.build' do
     subject { described_class }
     context 'with an invalid Dockerfile' do
-      it 'throws a UnexpectedResponseError' do
+      it 'throws a UnexpectedResponseError', docker_1_13: false do
         expect { subject.build('lololol') }
             .to raise_error(Docker::Error::UnexpectedResponseError)
+      end
+
+      it 'throws a ClientError', docker_1_13: true do
+        expect { subject.build('lololol') }
+            .to raise_error(Docker::Error::ClientError)
       end
     end
 

--- a/spec/docker/image_spec.rb
+++ b/spec/docker/image_spec.rb
@@ -653,12 +653,12 @@ describe Docker::Image do
   describe '.build' do
     subject { described_class }
     context 'with an invalid Dockerfile' do
-      it 'throws a UnexpectedResponseError', docker_1_13: false do
+      it 'throws a UnexpectedResponseError', docker_17_06: false do
         expect { subject.build('lololol') }
             .to raise_error(Docker::Error::UnexpectedResponseError)
       end
 
-      it 'throws a ClientError', docker_1_13: true do
+      it 'throws a ClientError', docker_17_06: true do
         expect { subject.build('lololol') }
             .to raise_error(Docker::Error::ClientError)
       end

--- a/spec/docker/image_spec.rb
+++ b/spec/docker/image_spec.rb
@@ -653,12 +653,12 @@ describe Docker::Image do
   describe '.build' do
     subject { described_class }
     context 'with an invalid Dockerfile' do
-      it 'throws a UnexpectedResponseError', docker_17_06: false do
+      it 'throws a UnexpectedResponseError', docker_17_09: false do
         expect { subject.build('lololol') }
             .to raise_error(Docker::Error::UnexpectedResponseError)
       end
 
-      it 'throws a ClientError', docker_17_06: true do
+      it 'throws a ClientError', docker_17_09: true do
         expect { subject.build('lololol') }
             .to raise_error(Docker::Error::ClientError)
       end

--- a/spec/docker_spec.rb
+++ b/spec/docker_spec.rb
@@ -173,10 +173,9 @@ describe Docker do
 
     let(:info) { subject.info }
     let(:keys) do
-      %w(Containers Debug DockerRootDir Driver DriverStatus ExecutionDriver ID
-         IPv4Forwarding Images IndexServerAddress KernelVersion Labels MemTotal
-         MemoryLimit NCPU NEventsListener NFd NGoroutines Name
-         OperatingSystem SwapLimit)
+      %w(Containers Debug DockerRootDir Driver DriverStatus ID IPv4Forwarding
+         Images IndexServerAddress KernelVersion Labels MemTotal MemoryLimit
+         NCPU NEventsListener NFd NGoroutines Name OperatingSystem SwapLimit)
     end
 
     it 'returns the info as a Hash' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -90,5 +90,17 @@ RSpec.configure do |config|
     config.filter_run_excluding :docker_1_12 => false
     config.filter_run_excluding :docker_1_13 => false
     config.filter_run_excluding :docker_old => true
+  when /^17\.06/
+    config.filter_run_excluding :docker_1_12 => false
+    config.filter_run_excluding :docker_1_13 => false
+    config.filter_run_excluding :docker_old => true
+  when /^17\.09/
+    config.filter_run_excluding :docker_1_12 => false
+    config.filter_run_excluding :docker_1_13 => false
+    config.filter_run_excluding :docker_old => true
+  when /^17\.12/
+    config.filter_run_excluding :docker_1_12 => false
+    config.filter_run_excluding :docker_1_13 => false
+    config.filter_run_excluding :docker_old => true
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,6 +48,7 @@ RSpec.configure do |config|
     config.filter_run_excluding :docker_1_12 => true
     config.filter_run_excluding :docker_1_13 => true
     config.filter_run_excluding :docker_17_03 => true
+    config.filter_run_excluding :docker_17_06 => true
   when /^1\.7/
     config.filter_run_excluding :docker_1_8 => true
     config.filter_run_excluding :docker_1_9 => true
@@ -56,6 +57,7 @@ RSpec.configure do |config|
     config.filter_run_excluding :docker_1_12 => true
     config.filter_run_excluding :docker_1_13 => true
     config.filter_run_excluding :docker_17_03 => true
+    config.filter_run_excluding :docker_17_06 => true
   when /^1\.8/
     config.filter_run_excluding :docker_1_9 => true
     config.filter_run_excluding :docker_1_10 => true
@@ -63,44 +65,54 @@ RSpec.configure do |config|
     config.filter_run_excluding :docker_1_12 => true
     config.filter_run_excluding :docker_1_13 => true
     config.filter_run_excluding :docker_17_03 => true
+    config.filter_run_excluding :docker_17_06 => true
   when /^1\.9/
     config.filter_run_excluding :docker_1_10 => true
     config.filter_run_excluding :docker_1_11 => true
     config.filter_run_excluding :docker_1_12 => true
     config.filter_run_excluding :docker_1_13 => true
     config.filter_run_excluding :docker_17_03 => true
+    config.filter_run_excluding :docker_17_06 => true
   when /^1\.10/
     config.filter_run_excluding :docker_1_11 => true
     config.filter_run_excluding :docker_1_12 => true
     config.filter_run_excluding :docker_1_13 => true
     config.filter_run_excluding :docker_17_03 => true
+    config.filter_run_excluding :docker_17_06 => true
   when /^1\.11/
     config.filter_run_excluding :docker_1_12 => true
     config.filter_run_excluding :docker_1_13 => true
     config.filter_run_excluding :docker_17_03 => true
+    config.filter_run_excluding :docker_17_06 => true
   when /^1\.12/
     config.filter_run_excluding :docker_1_12 => false
     config.filter_run_excluding :docker_1_13 => true
     config.filter_run_excluding :docker_17_03 => true
+    config.filter_run_excluding :docker_17_06 => true
   when /^1\.13/
     config.filter_run_excluding :docker_1_12 => false
     config.filter_run_excluding :docker_1_13 => false
     config.filter_run_excluding :docker_17_03 => true
+    config.filter_run_excluding :docker_17_06 => true
   when /^17\.03/
     config.filter_run_excluding :docker_1_12 => false
     config.filter_run_excluding :docker_1_13 => false
+    config.filter_run_excluding :docker_17_06 => true
     config.filter_run_excluding :docker_old => true
   when /^17\.06/
     config.filter_run_excluding :docker_1_12 => false
     config.filter_run_excluding :docker_1_13 => false
+    config.filter_run_excluding :docker_17_06 => false
     config.filter_run_excluding :docker_old => true
   when /^17\.09/
     config.filter_run_excluding :docker_1_12 => false
     config.filter_run_excluding :docker_1_13 => false
+    config.filter_run_excluding :docker_17_06 => false
     config.filter_run_excluding :docker_old => true
   when /^17\.12/
     config.filter_run_excluding :docker_1_12 => false
     config.filter_run_excluding :docker_1_13 => false
+    config.filter_run_excluding :docker_17_06 => false
     config.filter_run_excluding :docker_old => true
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,9 +84,11 @@ RSpec.configure do |config|
     config.filter_run_excluding :docker_17_03 => true
   when /^1\.13/
     config.filter_run_excluding :docker_1_12 => false
+    config.filter_run_excluding :docker_1_13 => false
     config.filter_run_excluding :docker_17_03 => true
   when /^17\.03/
     config.filter_run_excluding :docker_1_12 => false
+    config.filter_run_excluding :docker_1_13 => false
     config.filter_run_excluding :docker_old => true
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,6 +38,8 @@ RSpec.configure do |config|
   config.tty = true
   config.include SpecHelpers
 
+  # true -> exclude tests that require this version
+  # false -> exclude tests that stop working on and past this version
   case ENV['DOCKER_VERSION']
   when /^1\.6/
     config.filter_run_excluding :docker_1_7 => true
@@ -49,6 +51,7 @@ RSpec.configure do |config|
     config.filter_run_excluding :docker_1_13 => true
     config.filter_run_excluding :docker_17_03 => true
     config.filter_run_excluding :docker_17_06 => true
+    config.filter_run_excluding :docker_17_09 => true
   when /^1\.7/
     config.filter_run_excluding :docker_1_8 => true
     config.filter_run_excluding :docker_1_9 => true
@@ -58,6 +61,7 @@ RSpec.configure do |config|
     config.filter_run_excluding :docker_1_13 => true
     config.filter_run_excluding :docker_17_03 => true
     config.filter_run_excluding :docker_17_06 => true
+    config.filter_run_excluding :docker_17_09 => true
   when /^1\.8/
     config.filter_run_excluding :docker_1_9 => true
     config.filter_run_excluding :docker_1_10 => true
@@ -66,6 +70,7 @@ RSpec.configure do |config|
     config.filter_run_excluding :docker_1_13 => true
     config.filter_run_excluding :docker_17_03 => true
     config.filter_run_excluding :docker_17_06 => true
+    config.filter_run_excluding :docker_17_09 => true
   when /^1\.9/
     config.filter_run_excluding :docker_1_10 => true
     config.filter_run_excluding :docker_1_11 => true
@@ -73,46 +78,55 @@ RSpec.configure do |config|
     config.filter_run_excluding :docker_1_13 => true
     config.filter_run_excluding :docker_17_03 => true
     config.filter_run_excluding :docker_17_06 => true
+    config.filter_run_excluding :docker_17_09 => true
   when /^1\.10/
     config.filter_run_excluding :docker_1_11 => true
     config.filter_run_excluding :docker_1_12 => true
     config.filter_run_excluding :docker_1_13 => true
     config.filter_run_excluding :docker_17_03 => true
     config.filter_run_excluding :docker_17_06 => true
+    config.filter_run_excluding :docker_17_09 => true
   when /^1\.11/
     config.filter_run_excluding :docker_1_12 => true
     config.filter_run_excluding :docker_1_13 => true
     config.filter_run_excluding :docker_17_03 => true
     config.filter_run_excluding :docker_17_06 => true
+    config.filter_run_excluding :docker_17_09 => true
   when /^1\.12/
     config.filter_run_excluding :docker_1_12 => false
     config.filter_run_excluding :docker_1_13 => true
     config.filter_run_excluding :docker_17_03 => true
     config.filter_run_excluding :docker_17_06 => true
+    config.filter_run_excluding :docker_17_09 => true
   when /^1\.13/
     config.filter_run_excluding :docker_1_12 => false
     config.filter_run_excluding :docker_1_13 => false
     config.filter_run_excluding :docker_17_03 => true
     config.filter_run_excluding :docker_17_06 => true
+    config.filter_run_excluding :docker_17_09 => true
   when /^17\.03/
     config.filter_run_excluding :docker_1_12 => false
     config.filter_run_excluding :docker_1_13 => false
     config.filter_run_excluding :docker_17_06 => true
+    config.filter_run_excluding :docker_17_09 => true
     config.filter_run_excluding :docker_old => true
   when /^17\.06/
     config.filter_run_excluding :docker_1_12 => false
     config.filter_run_excluding :docker_1_13 => false
     config.filter_run_excluding :docker_17_06 => false
+    config.filter_run_excluding :docker_17_09 => true
     config.filter_run_excluding :docker_old => true
   when /^17\.09/
     config.filter_run_excluding :docker_1_12 => false
     config.filter_run_excluding :docker_1_13 => false
     config.filter_run_excluding :docker_17_06 => false
+    config.filter_run_excluding :docker_17_09 => false
     config.filter_run_excluding :docker_old => true
   when /^17\.12/
     config.filter_run_excluding :docker_1_12 => false
     config.filter_run_excluding :docker_1_13 => false
     config.filter_run_excluding :docker_17_06 => false
+    config.filter_run_excluding :docker_17_09 => false
     config.filter_run_excluding :docker_old => true
   end
 end


### PR DESCRIPTION
Holding this back to this version limits us whenever new versions of docker come out. Removing this will give us different responses between versions of docker, but we've seen that even when not changing the API version.

Perhaps this is best merged into a 2.0 pre-release with what ever cleanup we want to add versus adding to 1.0.

Thoughts?