### PR TITLE
Disable idempotency when streaming logs, as the operation is not idempotent for the gem consumer

### DIFF
--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -192,7 +192,7 @@ class Docker::Container
     stack_size = opts.delete('stack_size') || -1
     tty = opts.delete('tty') || opts.delete(:tty) || false
     msgs = Docker::MessagesStack.new(stack_size)
-    excon_params = {response_block: Docker::Util.attach_for(block, msgs, tty)}
+    excon_params = {response_block: Docker::Util.attach_for(block, msgs, tty), idempotent: false}
 
     connection.get(path_for(:logs), opts, excon_params)
     msgs.messages.join


### PR DESCRIPTION
Explanation:

When streaming logs of a container with any size of tail, if there is no log for a while (until the Timeout duration), excon is trying again the request as it is said as idempotent here:

https://github.com/swipely/docker-api/blob/c1387816b6a9d88fe0e26a81af0f4bb3533a18a2/lib/docker/connection.rb#L89

However the tail which has already been sent through the argument block is.. sent again, resulting in having multiple times all the logs coming through the block.

As a result the following code doesn't work (its goal is to restart the streaming after a timeout, without getting existing logs)

```ruby
tail = "all"
begin
  container.streaming_logs(follow: true, stderr: true, stdout: true, tail: tail) do |stream, chunk|
    puts chunk
  end
rescue ::Docker::Error::TimeoutError
  tail = 0
  retry
end
```

The rescue block is not taken into account until excon has done X retries of the request, dumping all the logs each time.

Regards,