### PR TITLE
add Docker-CE 18.03.0 to the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - 2.1
   - 2.0
 env:
+  - DOCKER_VERSION=18.03.0~ce-0~ubuntu DOCKER_CE=1
   - DOCKER_VERSION=17.03.1~ce-0~ubuntu-trusty DOCKER_CE=1
   - DOCKER_VERSION=1.13.1-0~ubuntu-trusty
   - DOCKER_VERSION=1.12.3-0~trusty

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -88,5 +88,8 @@ RSpec.configure do |config|
   when /^17\.03/
     config.filter_run_excluding :docker_1_12 => false
     config.filter_run_excluding :docker_old => true
+  when /^18\.03/
+    config.filter_run_excluding :docker_1_12 => false
+    config.filter_run_excluding :docker_old => true
   end
 end


### PR DESCRIPTION
Noticed some 502 Bad Gateway connection errors locally with macOS Docker-CE 18.03.0 and a gem that uses this gem.