### PR TITLE
Accept stack size as string or symbol

### DIFF
--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -189,7 +189,7 @@ class Docker::Container
   end
 
   def streaming_logs(opts = {}, &block)
-    stack_size = opts.delete('stack_size') || -1
+    stack_size = opts.delete('stack_size') || opts.delete(:stack_size) || -1
     tty = opts.delete('tty') || opts.delete(:tty) || false
     msgs = Docker::MessagesStack.new(stack_size)
     excon_params = {response_block: Docker::Util.attach_for(block, msgs, tty), idempotent: false}


### PR DESCRIPTION
Other options to the `streaming_logs` method read options as strings or symbols. This patch makes the `stack_size` option behave the same way.