### PR TITLE
Convert hash query arguments to json

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,14 @@ Docker::Image.build_from_dir('.') do |v|
   end
 end
 
+# Create an Image from a Dockerfile with buildargs
+Docker::Image.build_from_dir('.', {
+  'buildargs' => {
+    'arg1' => 'value1',
+    'arg2' => 'value2'
+  }
+})
+
 # Create an Image from a tar file.
 # docker command for reference: docker build - < docker_image.tar
 Docker::Image.build_from_tar(File.open('docker_image.tar', 'r'))

--- a/lib/docker/connection.rb
+++ b/lib/docker/connection.rb
@@ -81,7 +81,7 @@ private
     {
       :method        => http_method,
       :path          => "/v#{Docker::API_VERSION}#{path}",
-      :query         => query,
+      :query         => compile_nested_request_hash(query),
       :headers       => { 'Content-Type' => content_type,
                           'User-Agent'   => user_agent,
                         }.merge(headers),
@@ -89,5 +89,16 @@ private
       :idempotent    => http_method == :get,
       :request_block => block,
     }.merge(opts).reject { |_, v| v.nil? }
+  end
+
+  def compile_nested_request_hash(query = nil)
+    return query unless query.respond_to?(:each_with_object)
+    query.each_with_object({}) do |(k, v), h|
+      h[k] = if v.is_a?(Hash)
+        MultiJson.dump(v)
+      else
+        v
+      end
+    end
   end
 end

--- a/spec/docker/connection_spec.rb
+++ b/spec/docker/connection_spec.rb
@@ -122,4 +122,43 @@ describe Docker::Connection do
       expect(subject.to_s).to eq expected_string
     end
   end
+
+  describe '#compile_request_params' do
+    let(:url) { 'http://localhost:4243' }
+    let(:method) { :get }
+    let(:path) { '/test/' }
+    let(:query) do
+      {
+        'simple' => true,
+        'complex' => {
+          'test' => 'hash',
+          'query' => 'to_json'
+        }
+      }
+    end
+    let(:options) do
+      {
+        expects: 201,
+        headers: {'X-Custom-Header' => 'RSpec Testing'},
+      }
+    end
+
+    let(:compiled_params) do
+      {
+        expects: 201,
+        headers: { 'Content-Type'    => 'text/plain',
+                   'User-Agent'      => "Swipely/Docker-API #{Docker::VERSION}",
+                   'X-Custom-Header' => 'RSpec Testing'
+        },
+        idempotent: true,
+        method: :get,
+        path: "/v#{Docker::API_VERSION}#{path}",
+        query: { 'simple' => true, 'complex' => '{"test":"hash","query":"to_json"}' }
+      }
+    end
+    subject { described_class.new(url, options) }
+    it 'creates a request hash' do
+      expect(subject.send(:compile_request_params, method, path, query, options)).to eq compiled_params
+    end
+  end
 end


### PR DESCRIPTION
When supplying build arguments, up till now, the user was responsible for
making sure they were json encoded. This change makes sure that whenever
a hash is supplied as value for a query parameter, it is automatically
converted.