### PR TITLE
Handle exclusions when ignoring files

### DIFF
--- a/lib/docker/util.rb
+++ b/lib/docker/util.rb
@@ -259,7 +259,7 @@ module Docker::Util
   end
 
   def glob_all_files(pattern)
-    Dir.glob(pattern, File::FNM_DOTMATCH) - ['..', '.']
+    Dir.glob(pattern, File::FNM_DOTMATCH)
   end
 
   def remove_ignored_files!(directory, files)
@@ -268,11 +268,23 @@ module Docker::Util
     ignored_files(directory, ignore).each { |f| files.delete(f) }
   end
 
-  def ignored_files(directory, ignore_file)
-    patterns = File.read(ignore_file).split("\n").each(&:strip!)
-    patterns.reject! { |p| p.empty? || p.start_with?('#') }
+  def resolve_patterns(patterns, directory)
     patterns.map! { |p| File.join(directory, p) }
     patterns.map! { |p| File.directory?(p) ? "#{p}/**/*" : p }
     patterns.flat_map { |p| p =~ GLOB_WILDCARDS ? glob_all_files(p) : p }
+  end
+
+  def ignored_files(directory, ignore_file)
+    patterns = File.read(ignore_file).split("\n").each(&:strip!)
+    patterns.reject! { |p| p.empty? || p.start_with?('#') }
+
+    exclusion_patterns = patterns.select { |p| p.start_with?('!') }
+    inclusion_patterns = patterns - exclusion_patterns
+    exclusion_patterns.map! { |p| p[1..-1] }.concat(%w(Dockerfile .dockerignore))
+
+    files_ignored = resolve_patterns(inclusion_patterns, directory)
+    files_excluded = resolve_patterns(exclusion_patterns, directory)
+
+    files_ignored - files_excluded - [File.join(directory, '.'), File.join(directory, '..')]
   end
 end


### PR DESCRIPTION
Always exclude Dockerfile and .dockerignore from being ignored.

https://docs.docker.com/engine/reference/builder/#dockerignore-file
> You can even use the .dockerignore file to exclude the Dockerfile and .dockerignore files.
> These files are still sent to the daemon because it needs them to do its job.
> But the ADD and COPY instructions do not copy them to the image.

resolves #484