### PR TITLE
Replace deprecated URI.encode with CGI.escape

### DIFF
--- a/lib/docker/image.rb
+++ b/lib/docker/image.rb
@@ -126,7 +126,7 @@ class Docker::Image
 
     # Return a specific image.
     def get(id, opts = {}, conn = Docker.connection)
-      image_json = conn.get("/images/#{URI.encode(id)}/json", opts)
+      image_json = conn.get("/images/#{CGI.escape(id)}/json", opts)
       hash = Docker::Util.parse_json(image_json) || {}
       new(conn, hash)
     end


### PR DESCRIPTION
`URI.escape` and `URI.encode` are deprecated, this PR replaces the `URI.encode` method call with `CGI.escape`

![image](https://user-images.githubusercontent.com/9844923/71549468-e9d68600-29f8-11ea-84a4-59fce2e80bef.png)
