### PR TITLE
Specify version of bundler to be used in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
   fast_finish: true
 before_install:
  - docker --version
- - gem install bundler
+ - gem install bundler -v 1.17.3
 before_script:
  - sudo ./script/install_docker.sh ${DOCKER_VERSION} ${DOCKER_CE}
  - uname -a


### PR DESCRIPTION
Specify a version of bundler to use with Travis as it seems like the CI tests for older versions of Ruby are failing because of version incompatibilities with Bundler

![image](https://user-images.githubusercontent.com/9844923/71549482-273b1380-29f9-11ea-974a-f91713675862.png)
