### PR TITLE
Version 2 pre-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ rvm:
   - 2.1
   - 2.0
 env:
+  - DOCKER_VERSION=17.12.0~ce-0~ubuntu DOCKER_CE=1
+  - DOCKER_VERSION=17.09.1~ce-0~ubuntu DOCKER_CE=1
+  - DOCKER_VERSION=17.06.2~ce-0~ubuntu DOCKER_CE=1
   - DOCKER_VERSION=17.03.1~ce-0~ubuntu-trusty DOCKER_CE=1
   - DOCKER_VERSION=1.13.1-0~ubuntu-trusty
   - DOCKER_VERSION=1.12.3-0~trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,19 @@
-sudo: required
-dist: trusty
+os: linux
+dist: bionic
 language: ruby
 cache: bundler
 rvm:
-  - 2.3.1
+  - 2.7
+  - 2.6
+  - 2.5
+  - 2.4
+  - 2.3
   - 2.2
-  - 2.1
-  - 2.0
 env:
-  - DOCKER_VERSION=17.12.0~ce-0~ubuntu DOCKER_CE=1
-  - DOCKER_VERSION=17.09.1~ce-0~ubuntu DOCKER_CE=1
-  - DOCKER_VERSION=17.06.2~ce-0~ubuntu DOCKER_CE=1
-  - DOCKER_VERSION=17.03.1~ce-0~ubuntu-trusty DOCKER_CE=1
-  - DOCKER_VERSION=1.13.1-0~ubuntu-trusty
-  - DOCKER_VERSION=1.12.3-0~trusty
-  - DOCKER_VERSION=1.11.1-0~trusty
-  - DOCKER_VERSION=1.10.3-0~trusty
-  - DOCKER_VERSION=1.9.1-0~trusty
-  - DOCKER_VERSION=1.8.2-0~trusty
-matrix:
+  - DOCKER_VERSION=5:19.03.8~3-0~ubuntu-bionic
+  - DOCKER_VERSION=5:18.09.9~3-0~ubuntu-bionic
+  - DOCKER_VERSION=18.06.3~ce~3-0~ubuntu
+jobs:
   fast_finish: true
 before_install:
  - docker --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jobs:
   fast_finish: true
 before_install:
  - docker --version
- - gem install bundler
+ - gem install bundler -v '~> 1.17.3'
 before_script:
  - sudo ./script/install_docker.sh ${DOCKER_VERSION} ${DOCKER_CE}
  - uname -a

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ container.read_file("/test")
 
 # Export a Container. Since an export is typically at least 300M, chunks of the
 # export are yielded instead of just returning the whole thing.
-File.open('export.tar', 'w') do |f|
+File.open('export.tar', 'w') do |file|
   container.export { |chunk| file.write(chunk) }
 end
 # => nil

--- a/README.md
+++ b/README.md
@@ -622,10 +622,6 @@ image 'repo:new_tag' => 'repo:tag' do
 end
 ```
 
-## Known issues
-
-*   If the docker daemon is always responding to your requests with a 400 Bad Request when using UNIX sockets, verify you're running Excon version 0.46.0 or greater. [Link](https://github.com/swipely/docker-api/issues/381)
-
 ## Not supported (yet)
 
 *   Generating a tarball of images and metadata for a repository specified by a name: https://docs.docker.com/engine/reference/api/docker_remote_api_v1.14/#get-a-tarball-containing-all-images-and-tags-in-a-repository

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 docker-api
 ==========
-[![Gem Version](https://badge.fury.io/rb/docker-api.svg)](https://badge.fury.io/rb/docker-api) [![travis-ci](https://travis-ci.org/swipely/docker-api.svg?branch=master)](https://travis-ci.org/swipely/docker-api) [![Code Climate](https://codeclimate.com/github/swipely/docker-api.svg)](https://codeclimate.com/github/swipely/docker-api) [![Dependency Status](https://gemnasium.com/swipely/docker-api.svg)](https://gemnasium.com/swipely/docker-api)
+[![Gem Version](https://badge.fury.io/rb/docker-api.svg)](https://badge.fury.io/rb/docker-api) [![travis-ci](https://travis-ci.org/swipely/docker-api.svg?branch=master)](https://travis-ci.org/swipely/docker-api) [![Code Climate](https://codeclimate.com/github/swipely/docker-api.svg)](https://codeclimate.com/github/swipely/docker-api)
 
-This gem provides an object-oriented interface to the [Docker Remote API](https://docs.docker.com/reference/api/docker_remote_api/). Every method listed there is implemented. At the time of this writing, docker-api is meant to interface with Docker version 1.3.*
+This gem provides an object-oriented interface to the [Docker Engine API](https://docs.docker.com/develop/sdk/). Every method listed there is implemented. At the time of this writing, docker-api is meant to interface with Docker version 1.4.*
 
 If you're interested in using Docker to package your apps, we recommend the [dockly](https://github.com/swipely/dockly) gem. Dockly provides a simple DSL for describing Docker containers that install as Debian packages and are controlled by upstart scripts.
 
@@ -36,7 +36,7 @@ docker-api is designed to be very lightweight. Almost no state is cached (aside 
 
 ## Starting up
 
-Follow the [installation instructions](https://docs.docker.com/installation/#installation), and then run:
+Follow the [installation instructions](https://docs.docker.com/install/), and then run:
 
 ```shell
 $ sudo docker -d
@@ -52,7 +52,7 @@ If you're running Docker locally as a socket, there is no setup to do in Ruby. I
 Docker.url = 'tcp://example.com:5422'
 ```
 
-Two things to note here. The first is that this gem uses [excon](http://www.github.com/geemus/excon), so any of the options that are valid for `Excon.new` are also valid for `Docker.options`. Second, by default Docker runs on a socket. The gem will assume you want to connect to the socket unless you specify otherwise.
+Two things to note here. The first is that this gem uses [excon](https://github.com/excon/excon), so any of the options that are valid for `Excon.new` are also valid for `Docker.options`. Second, by default Docker runs on a socket. The gem will assume you want to connect to the socket unless you specify otherwise.
 
 Also, you may set the above variables via `ENV` variables. For example:
 

--- a/lib/docker.rb
+++ b/lib/docker.rb
@@ -129,19 +129,8 @@ module Docker
     raise Docker::Error::AuthenticationError
   end
 
-  # When the correct version of Docker is installed, returns true. Otherwise,
-  # raises a VersionError.
-  def validate_version!
-    Docker.info
-    true
-  rescue Docker::Error::TimeoutError
-    raise
-  rescue Docker::Error::DockerError
-    raise Docker::Error::VersionError, "Expected API Version: #{API_VERSION}"
-  end
-
   module_function :default_socket_url, :env_url, :url, :url=, :env_options,
                   :options, :options=, :creds, :creds=, :logger, :logger=,
                   :connection, :reset!, :reset_connection!, :version, :info,
-                  :ping, :authenticate!, :validate_version!, :ssl_options
+                  :ping, :authenticate!, :ssl_options
 end

--- a/lib/docker/connection.rb
+++ b/lib/docker/connection.rb
@@ -80,7 +80,7 @@ private
     user_agent = "Swipely/Docker-API #{Docker::VERSION}"
     {
       :method        => http_method,
-      :path          => "/v#{Docker::API_VERSION}#{path}",
+      :path          => path,
       :query         => query,
       :headers       => { 'Content-Type' => content_type,
                           'User-Agent'   => user_agent,

--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -343,7 +343,7 @@ class Docker::Container
 
   # Return the container with specified ID
   def self.get(id, opts = {}, conn = Docker.connection)
-    container_json = conn.get("/containers/#{URI.encode(id)}/json", opts)
+    container_json = conn.get("/containers/#{CGI.escape(id)}/json", opts)
     hash = Docker::Util.parse_json(container_json) || {}
     new(conn, hash)
   end

--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -343,7 +343,7 @@ class Docker::Container
 
   # Return the container with specified ID
   def self.get(id, opts = {}, conn = Docker.connection)
-    container_json = conn.get("/containers/#{CGI.escape(id)}/json", opts)
+    container_json = conn.get("/containers/#{id}/json", opts)
     hash = Docker::Util.parse_json(container_json) || {}
     new(conn, hash)
   end

--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -266,16 +266,6 @@ class Docker::Container
     end
   end
 
-  def copy(path, &block)
-    connection.post(
-      path_for(:copy),
-      {},
-      body: MultiJson.dump('Resource' => path),
-      response_block: block
-    )
-    self
-  end
-
   def archive_out(path, &block)
     connection.get(
       path_for(:archive),

--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -189,7 +189,7 @@ class Docker::Container
   end
 
   def streaming_logs(opts = {}, &block)
-    stack_size = opts.delete('stack_size') || -1
+    stack_size = opts.delete('stack_size') || opts.delete(:stack_size) || -1
     tty = opts.delete('tty') || opts.delete(:tty) || false
     msgs = Docker::MessagesStack.new(stack_size)
     excon_params = {response_block: Docker::Util.attach_for(block, msgs, tty), idempotent: false}

--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -192,7 +192,7 @@ class Docker::Container
     stack_size = opts.delete('stack_size') || -1
     tty = opts.delete('tty') || opts.delete(:tty) || false
     msgs = Docker::MessagesStack.new(stack_size)
-    excon_params = {response_block: Docker::Util.attach_for(block, msgs, tty)}
+    excon_params = {response_block: Docker::Util.attach_for(block, msgs, tty), idempotent: false}
 
     connection.get(path_for(:logs), opts, excon_params)
     msgs.messages.join

--- a/lib/docker/event.rb
+++ b/lib/docker/event.rb
@@ -29,7 +29,9 @@ class Docker::Event
 
     def stream(opts = {}, conn = Docker.connection, &block)
       conn.get('/events', opts, :response_block => lambda { |b, r, t|
-        block.call(new_event(b, r, t))
+        b.each_line do |line|
+          block.call(new_event(line, r, t))
+        end
       })
     end
 

--- a/lib/docker/image.rb
+++ b/lib/docker/image.rb
@@ -126,7 +126,7 @@ class Docker::Image
 
     # Return a specific image.
     def get(id, opts = {}, conn = Docker.connection)
-      image_json = conn.get("/images/#{URI.encode(id)}/json", opts)
+      image_json = conn.get("/images/#{CGI.escape(id)}/json", opts)
       hash = Docker::Util.parse_json(image_json) || {}
       new(conn, hash)
     end

--- a/lib/docker/image.rb
+++ b/lib/docker/image.rb
@@ -126,7 +126,7 @@ class Docker::Image
 
     # Return a specific image.
     def get(id, opts = {}, conn = Docker.connection)
-      image_json = conn.get("/images/#{CGI.escape(id)}/json", opts)
+      image_json = conn.get("/images/#{id}/json", opts)
       hash = Docker::Util.parse_json(image_json) || {}
       new(conn, hash)
     end
@@ -174,7 +174,7 @@ class Docker::Image
       # By using compare_by_identity we can create a Hash that has
       # the same key multiple times.
       query = {}.tap(&:compare_by_identity)
-      Array(names).each { |name| query['names'.dup] = CGI.escape(name) }
+      Array(names).each { |name| query['names'.dup] = name }
       conn.get(
         '/images/get',
         query,

--- a/lib/docker/image.rb
+++ b/lib/docker/image.rb
@@ -174,7 +174,7 @@ class Docker::Image
       # By using compare_by_identity we can create a Hash that has
       # the same key multiple times.
       query = {}.tap(&:compare_by_identity)
-      Array(names).each { |name| query['names'.dup] = URI.encode(name) }
+      Array(names).each { |name| query['names'.dup] = CGI.escape(name) }
       conn.get(
         '/images/get',
         query,

--- a/lib/docker/network.rb
+++ b/lib/docker/network.rb
@@ -34,7 +34,7 @@ class Docker::Network
   end
 
   def reload
-    network_json = @connection.get("/networks/#{URI.encode(@id)}")
+    network_json = @connection.get("/networks/#{CGI.escape(@id)}")
     hash = Docker::Util.parse_json(network_json) || {}
     @info = hash
   end
@@ -51,7 +51,7 @@ class Docker::Network
     end
 
     def get(id, opts = {}, conn = Docker.connection)
-      network_json = conn.get("/networks/#{URI.encode(id)}", opts)
+      network_json = conn.get("/networks/#{CGI.escape(id)}", opts)
       hash = Docker::Util.parse_json(network_json) || {}
       new(conn, hash)
     end
@@ -62,7 +62,7 @@ class Docker::Network
     end
 
     def remove(id, opts = {}, conn = Docker.connection)
-      conn.delete("/networks/#{URI.encode(id)}", opts)
+      conn.delete("/networks/#{CGI.escape(id)}", opts)
       nil
     end
     alias_method :delete, :remove

--- a/lib/docker/network.rb
+++ b/lib/docker/network.rb
@@ -34,7 +34,7 @@ class Docker::Network
   end
 
   def reload
-    network_json = @connection.get("/networks/#{CGI.escape(@id)}")
+    network_json = @connection.get("/networks/#{@id}")
     hash = Docker::Util.parse_json(network_json) || {}
     @info = hash
   end
@@ -51,7 +51,7 @@ class Docker::Network
     end
 
     def get(id, opts = {}, conn = Docker.connection)
-      network_json = conn.get("/networks/#{CGI.escape(id)}", opts)
+      network_json = conn.get("/networks/#{id}", opts)
       hash = Docker::Util.parse_json(network_json) || {}
       new(conn, hash)
     end
@@ -62,7 +62,7 @@ class Docker::Network
     end
 
     def remove(id, opts = {}, conn = Docker.connection)
-      conn.delete("/networks/#{CGI.escape(id)}", opts)
+      conn.delete("/networks/#{id}", opts)
       nil
     end
     alias_method :delete, :remove

--- a/lib/docker/util.rb
+++ b/lib/docker/util.rb
@@ -241,8 +241,9 @@ module Docker::Util
 
   def build_config_header(credentials)
     if credentials.is_a?(String)
-      credentials = JSON.parse(credentials, symbolize_names: true)
+      credentials = MultiJson.load(credentials, symbolize_keys: true)
     end
+
     header = MultiJson.dump(
       credentials[:serveraddress].to_s => {
         'username' => credentials[:username].to_s,

--- a/lib/docker/version.rb
+++ b/lib/docker/version.rb
@@ -1,6 +1,6 @@
 module Docker
   # The version of the docker-api gem.
-  VERSION = '1.33.6'
+  VERSION = '1.34.0'
 
   # The version of the compatible Docker remote API.
   API_VERSION = '1.16'

--- a/lib/docker/version.rb
+++ b/lib/docker/version.rb
@@ -1,6 +1,6 @@
 module Docker
   # The version of the docker-api gem.
-  VERSION = '1.34.1'
+  VERSION = '1.34.2'
 
   # The version of the compatible Docker remote API.
   API_VERSION = '1.16'

--- a/lib/docker/version.rb
+++ b/lib/docker/version.rb
@@ -1,4 +1,4 @@
 module Docker
   # The version of the docker-api gem.
-  VERSION = '1.34.2'
+  VERSION = '2.0.0.pre.1'
 end

--- a/lib/docker/version.rb
+++ b/lib/docker/version.rb
@@ -1,6 +1,6 @@
 module Docker
   # The version of the docker-api gem.
-  VERSION = '1.34.0'
+  VERSION = '1.34.1'
 
   # The version of the compatible Docker remote API.
   API_VERSION = '1.16'

--- a/lib/docker/version.rb
+++ b/lib/docker/version.rb
@@ -1,7 +1,4 @@
 module Docker
   # The version of the docker-api gem.
   VERSION = '1.34.2'
-
-  # The version of the compatible Docker remote API.
-  API_VERSION = '1.16'
 end

--- a/script/install_docker.sh
+++ b/script/install_docker.sh
@@ -10,7 +10,7 @@ DOCKER_CE=$2
 
 # disable travis default installation
 #service docker stop
-apt-get -y --purge remove docker docker-engine
+apt-get -y --purge remove docker docker-engine docker-ce
 
 if [ "$DOCKER_CE" = "1" ]; then
     # install gpg key for docker rpo

--- a/script/install_docker.sh
+++ b/script/install_docker.sh
@@ -19,9 +19,9 @@ if [ "$DOCKER_CE" = "1" ]; then
 
     # enable docker repo
     add-apt-repository \
-       "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-       $(lsb_release -cs) \
-       stable"
+      "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+      $(lsb_release -cs) \
+      stable"
     apt-get update
     apt-cache gencaches
 
@@ -29,7 +29,9 @@ if [ "$DOCKER_CE" = "1" ]; then
     apt-get install docker-ce=${DOCKER_VERSION}
 else
     # install gpg key for docker rpo
-    apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv 58118E89F3A912897C070ADBF76221572C52609D
+    apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv 58118E89F3A912897C070ADBF76221572C52609D || \
+      apt-key adv --keyserver pgp.mit.edu --recv 58118E89F3A912897C070ADBF76221572C52609D || \
+      apt-key adv --keyserver keyserver.pgp.com --recv 58118E89F3A912897C070ADBF76221572C52609D
 
     # enable docker repo
     echo 'deb "https://apt.dockerproject.org/repo" ubuntu-trusty main' >> /etc/apt/sources.list.d/docker-main.list

--- a/script/install_docker.sh
+++ b/script/install_docker.sh
@@ -9,38 +9,22 @@ DOCKER_VERSION=$1
 DOCKER_CE=$2
 
 # disable travis default installation
-#service docker stop
 apt-get -y --purge remove docker docker-engine docker-ce
 
-if [ "$DOCKER_CE" = "1" ]; then
-    # install gpg key for docker rpo
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-    apt-key fingerprint 0EBFCD88
+# install gpg key for docker rpo
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+apt-key fingerprint 0EBFCD88
 
-    # enable docker repo
-    add-apt-repository \
-      "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-      $(lsb_release -cs) \
-      stable"
-    apt-get update
-    apt-cache gencaches
+# enable docker repo
+add-apt-repository \
+  "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) \
+  stable"
+apt-get update
+apt-cache gencaches
 
-    # install package
-    apt-get install docker-ce=${DOCKER_VERSION}
-else
-    # install gpg key for docker rpo
-    apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv 58118E89F3A912897C070ADBF76221572C52609D || \
-      apt-key adv --keyserver pgp.mit.edu --recv 58118E89F3A912897C070ADBF76221572C52609D || \
-      apt-key adv --keyserver keyserver.pgp.com --recv 58118E89F3A912897C070ADBF76221572C52609D
-
-    # enable docker repo
-    echo 'deb "https://apt.dockerproject.org/repo" ubuntu-trusty main' >> /etc/apt/sources.list.d/docker-main.list
-    apt-get update -o Dir::Etc::sourcelist='sources.list.d/docker-main.list' -o Dir::Etc::sourceparts='-' -o APT::Get::List-Cleanup='0'
-    apt-cache gencaches
-
-    # install package
-    apt-get -y --force-yes install docker-engine=${DOCKER_VERSION}
-fi
+# install package
+apt-get install docker-ce=${DOCKER_VERSION}
 
 echo 'DOCKER_OPTS="-H unix:///var/run/docker.sock --pidfile=/var/run/docker.pid"' > /etc/default/docker
 cat /etc/default/docker

--- a/script/install_docker.sh
+++ b/script/install_docker.sh
@@ -9,6 +9,7 @@ DOCKER_VERSION=$1
 DOCKER_CE=$2
 
 # disable travis default installation
+systemctl stop docker.service
 apt-get -y --purge remove docker docker-engine docker-ce
 
 # install gpg key for docker rpo
@@ -25,6 +26,9 @@ apt-cache gencaches
 
 # install package
 apt-get install docker-ce=${DOCKER_VERSION}
+systemctl stop docker.service
 
 echo 'DOCKER_OPTS="-H unix:///var/run/docker.sock --pidfile=/var/run/docker.pid"' > /etc/default/docker
 cat /etc/default/docker
+
+systemctl start docker.service

--- a/spec/docker/connection_spec.rb
+++ b/spec/docker/connection_spec.rb
@@ -78,7 +78,7 @@ describe Docker::Connection do
     let(:expected_hash) {
       {
         :method  => method,
-        :path    => "/v#{Docker::API_VERSION}#{path}",
+        :path    => path,
         :query   => query,
         :headers => { 'Content-Type' => 'text/plain',
                       'User-Agent'   => "Swipely/Docker-API #{Docker::VERSION}",

--- a/spec/docker/container_spec.rb
+++ b/spec/docker/container_spec.rb
@@ -257,41 +257,6 @@ describe Docker::Container do
     end
   end
 
-  describe '#copy', docker_1_12: false do
-    let(:image) { Docker::Image.create('fromImage' => 'debian:wheezy') }
-    subject { image.run('touch /test').tap { |c| c.wait } }
-
-    after(:each) { subject.remove }
-
-    context 'when the file does not exist' do
-      it 'raises an error' do
-        expect { subject.copy('/lol/not/a/real/file') { |chunk| puts chunk } }
-          .to raise_error(
-            Docker::Error::NotFoundError,
-            %r{Could not find the file /lol/not/a/real/file in container}
-          )
-      end
-    end
-
-    context 'when the input is a file' do
-      it 'yields each chunk of the tarred file' do
-        chunks = []
-        subject.copy('/test') { |chunk| chunks << chunk }
-        chunks = chunks.join("\n")
-        expect(chunks).to be_include('test')
-      end
-    end
-
-    context 'when the input is a directory' do
-      it 'yields each chunk of the tarred directory' do
-        chunks = []
-        subject.copy('/etc/logrotate.d') { |chunk| chunks << chunk }
-        chunks = chunks.join("\n")
-        expect(%w[apt dpkg]).to be_all { |file| chunks.include?(file) }
-      end
-    end
-  end
-
   describe '#archive_in', :docker_1_8 do
     let(:license_path) { File.absolute_path(File.join(__FILE__, '..', '..', '..', 'LICENSE')) }
     subject { Docker::Container.create('Image' => 'debian:wheezy', 'Cmd' => ['/bin/sh']) }

--- a/spec/docker/container_spec.rb
+++ b/spec/docker/container_spec.rb
@@ -118,14 +118,6 @@ describe Docker::Container do
         end
         expect(called_count).to eq 2
       end
-
-      it "returns after :read_timeout if the container is not running", :docker_old do
-        called_count = 0
-        subject.stats(read_timeout: 3) do |output|
-          called_count += 1
-        end
-        expect(called_count).to eq 0
-      end
     end
   end
 
@@ -275,7 +267,7 @@ describe Docker::Container do
       it 'raises an error' do
         expect { subject.copy('/lol/not/a/real/file') { |chunk| puts chunk } }
           .to raise_error(
-            Docker::Error::ServerError,
+            Docker::Error::NotFoundError,
             %r{Could not find the file /lol/not/a/real/file in container}
           )
       end

--- a/spec/docker/event_spec.rb
+++ b/spec/docker/event_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-SingleCov.covered!
+SingleCov.covered! uncovered: 4
 
 describe Docker::Event do
   let(:api_response) do

--- a/spec/docker/image_spec.rb
+++ b/spec/docker/image_spec.rb
@@ -515,7 +515,7 @@ describe Docker::Image do
     let(:non_streamed) do
       Docker.connection.get(
         '/images/get',
-        'names' => URI.encode(image)
+        'names' => CGI.escape(image)
       )
     end
     let(:streamed) { '' }

--- a/spec/docker/image_spec.rb
+++ b/spec/docker/image_spec.rb
@@ -301,7 +301,7 @@ describe Docker::Image do
       after { container.remove }
 
       it 'returns 50' do
-        expect(container.json["Config"]["CpuShares"]).to eq 50
+        expect(container.json["HostConfig"]["CpuShares"]).to eq 50
       end
     end
   end
@@ -653,9 +653,14 @@ describe Docker::Image do
   describe '.build' do
     subject { described_class }
     context 'with an invalid Dockerfile' do
-      it 'throws a UnexpectedResponseError' do
+      it 'throws a UnexpectedResponseError', docker_17_09: false do
         expect { subject.build('lololol') }
             .to raise_error(Docker::Error::UnexpectedResponseError)
+      end
+
+      it 'throws a ClientError', docker_17_09: true do
+        expect { subject.build('lololol') }
+            .to raise_error(Docker::Error::ClientError)
       end
     end
 

--- a/spec/docker/image_spec.rb
+++ b/spec/docker/image_spec.rb
@@ -433,12 +433,12 @@ describe Docker::Image do
 
       before do
         Docker.creds = nil
-        subject.create('fromImage' => 'tianon/true').remove
+        subject.create('fromImage' => 'busybox').remove(force: true)
       end
 
       it 'calls the block and passes build output' do
-        subject.create('fromImage' => 'tianon/true', &block)
-        expect(create_output).to match(/Pulling.*tianon\/true/)
+        subject.create('fromImage' => 'busybox', &block)
+        expect(create_output).to match(/Pulling.*busybox/)
       end
     end
   end

--- a/spec/docker/image_spec.rb
+++ b/spec/docker/image_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-SingleCov.covered! uncovered: 3
+SingleCov.covered! uncovered: 9
 
 describe Docker::Image do
   describe '#to_s' do

--- a/spec/docker/image_spec.rb
+++ b/spec/docker/image_spec.rb
@@ -273,20 +273,6 @@ describe Docker::Image do
       end
     end
 
-    context 'when cmd is nil', docker_1_12: false do
-      let(:cmd) { nil }
-
-      context 'no command configured in image' do
-        subject { described_class.create('fromImage' => 'swipely/base') }
-        it 'should raise an error if no command is specified' do
-          expect { container }.to raise_error(
-            Docker::Error::ServerError,
-            /No\ command\ specified/
-          )
-        end
-      end
-    end
-
     context "command configured in image" do
       let(:cmd) { 'pwd' }
       after { container.remove }

--- a/spec/docker/image_spec.rb
+++ b/spec/docker/image_spec.rb
@@ -499,10 +499,7 @@ describe Docker::Image do
   describe '.save_stream' do
     let(:image) { 'busybox:latest' }
     let(:non_streamed) do
-      Docker.connection.get(
-        '/images/get',
-        'names' => CGI.escape(image)
-      )
+      Docker.connection.get('/images/get', 'names' => image)
     end
     let(:streamed) { '' }
     let(:tar_files) do
@@ -641,7 +638,7 @@ describe Docker::Image do
     context 'with an invalid Dockerfile' do
       it 'throws a UnexpectedResponseError', docker_17_09: false do
         expect { subject.build('lololol') }
-            .to raise_error(Docker::Error::UnexpectedResponseError)
+            .to raise_error(Docker::Error::ClientError)
       end
 
       it 'throws a ClientError', docker_17_09: true do

--- a/spec/docker/messages_spec.rb
+++ b/spec/docker/messages_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-SingleCov.covered! uncovered: 3
+SingleCov.covered! uncovered: 4
 
 describe Docker::Messages do
   shared_examples_for "two equal messages" do

--- a/spec/docker/network_spec.rb
+++ b/spec/docker/network_spec.rb
@@ -4,7 +4,7 @@ SingleCov.covered! uncovered: 2
 
 describe Docker::Network, docker_1_9: true do
   let(:name) do |example|
-    example.description.downcase.gsub('\s', '-')
+    example.description.downcase.gsub(/\s/, '-')
   end
 
   describe '#to_s' do

--- a/spec/docker_spec.rb
+++ b/spec/docker_spec.rb
@@ -173,10 +173,9 @@ describe Docker do
 
     let(:info) { subject.info }
     let(:keys) do
-      %w(Containers Debug DockerRootDir Driver DriverStatus ExecutionDriver ID
-         IPv4Forwarding Images IndexServerAddress KernelVersion Labels MemTotal
-         MemoryLimit NCPU NEventsListener NFd NGoroutines Name
-         OperatingSystem SwapLimit)
+      %w(Containers Debug DockerRootDir Driver DriverStatus ID IPv4Forwarding
+         Images IndexServerAddress KernelVersion Labels MemTotal MemoryLimit
+         NCPU NEventsListener NFd NGoroutines Name OperatingSystem SwapLimit)
     end
 
     it 'returns the info as a Hash' do

--- a/spec/docker_spec.rb
+++ b/spec/docker_spec.rb
@@ -238,34 +238,4 @@ describe Docker do
       end
     end
   end
-
-  describe '#validate_version' do
-    before { Docker.reset! }
-
-    context 'when a Docker Error is raised' do
-      before do
-        allow(Docker).to receive(:info).and_raise(Docker::Error::ClientError)
-      end
-
-      it 'raises a Version Error' do
-        expect { subject.validate_version! }
-            .to raise_error(Docker::Error::VersionError)
-      end
-    end
-
-    context 'when a connection times out' do
-      before do
-        allow(Docker).to receive(:info).and_raise(Docker::Error::TimeoutError)
-      end
-
-      it 'lets the user know that docker is unreachable' do
-        expect { subject.validate_version! }
-          .to raise_error(Docker::Error::TimeoutError)
-      end
-    end
-
-    context 'when nothing is raised' do
-      its(:validate_version!) { should be true }
-    end
-  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,6 +38,8 @@ RSpec.configure do |config|
   config.tty = true
   config.include SpecHelpers
 
+  # true -> exclude tests that require this version
+  # false -> exclude tests that stop working on and past this version
   case ENV['DOCKER_VERSION']
   when /^1\.6/
     config.filter_run_excluding :docker_1_7 => true
@@ -48,6 +50,8 @@ RSpec.configure do |config|
     config.filter_run_excluding :docker_1_12 => true
     config.filter_run_excluding :docker_1_13 => true
     config.filter_run_excluding :docker_17_03 => true
+    config.filter_run_excluding :docker_17_06 => true
+    config.filter_run_excluding :docker_17_09 => true
   when /^1\.7/
     config.filter_run_excluding :docker_1_8 => true
     config.filter_run_excluding :docker_1_9 => true
@@ -56,6 +60,8 @@ RSpec.configure do |config|
     config.filter_run_excluding :docker_1_12 => true
     config.filter_run_excluding :docker_1_13 => true
     config.filter_run_excluding :docker_17_03 => true
+    config.filter_run_excluding :docker_17_06 => true
+    config.filter_run_excluding :docker_17_09 => true
   when /^1\.8/
     config.filter_run_excluding :docker_1_9 => true
     config.filter_run_excluding :docker_1_10 => true
@@ -63,30 +69,64 @@ RSpec.configure do |config|
     config.filter_run_excluding :docker_1_12 => true
     config.filter_run_excluding :docker_1_13 => true
     config.filter_run_excluding :docker_17_03 => true
+    config.filter_run_excluding :docker_17_06 => true
+    config.filter_run_excluding :docker_17_09 => true
   when /^1\.9/
     config.filter_run_excluding :docker_1_10 => true
     config.filter_run_excluding :docker_1_11 => true
     config.filter_run_excluding :docker_1_12 => true
     config.filter_run_excluding :docker_1_13 => true
     config.filter_run_excluding :docker_17_03 => true
+    config.filter_run_excluding :docker_17_06 => true
+    config.filter_run_excluding :docker_17_09 => true
   when /^1\.10/
     config.filter_run_excluding :docker_1_11 => true
     config.filter_run_excluding :docker_1_12 => true
     config.filter_run_excluding :docker_1_13 => true
     config.filter_run_excluding :docker_17_03 => true
+    config.filter_run_excluding :docker_17_06 => true
+    config.filter_run_excluding :docker_17_09 => true
   when /^1\.11/
     config.filter_run_excluding :docker_1_12 => true
     config.filter_run_excluding :docker_1_13 => true
     config.filter_run_excluding :docker_17_03 => true
+    config.filter_run_excluding :docker_17_06 => true
+    config.filter_run_excluding :docker_17_09 => true
   when /^1\.12/
     config.filter_run_excluding :docker_1_12 => false
     config.filter_run_excluding :docker_1_13 => true
     config.filter_run_excluding :docker_17_03 => true
+    config.filter_run_excluding :docker_17_06 => true
+    config.filter_run_excluding :docker_17_09 => true
   when /^1\.13/
     config.filter_run_excluding :docker_1_12 => false
+    config.filter_run_excluding :docker_1_13 => false
     config.filter_run_excluding :docker_17_03 => true
+    config.filter_run_excluding :docker_17_06 => true
+    config.filter_run_excluding :docker_17_09 => true
   when /^17\.03/
     config.filter_run_excluding :docker_1_12 => false
+    config.filter_run_excluding :docker_1_13 => false
+    config.filter_run_excluding :docker_17_06 => true
+    config.filter_run_excluding :docker_17_09 => true
+    config.filter_run_excluding :docker_old => true
+  when /^17\.06/
+    config.filter_run_excluding :docker_1_12 => false
+    config.filter_run_excluding :docker_1_13 => false
+    config.filter_run_excluding :docker_17_06 => false
+    config.filter_run_excluding :docker_17_09 => true
+    config.filter_run_excluding :docker_old => true
+  when /^17\.09/
+    config.filter_run_excluding :docker_1_12 => false
+    config.filter_run_excluding :docker_1_13 => false
+    config.filter_run_excluding :docker_17_06 => false
+    config.filter_run_excluding :docker_17_09 => false
+    config.filter_run_excluding :docker_old => true
+  when /^17\.12/
+    config.filter_run_excluding :docker_1_12 => false
+    config.filter_run_excluding :docker_1_13 => false
+    config.filter_run_excluding :docker_17_06 => false
+    config.filter_run_excluding :docker_17_09 => false
     config.filter_run_excluding :docker_old => true
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,9 +7,7 @@ require 'rspec/its'
 require 'single_cov'
 
 # avoid coverage failure from lower docker versions not running all tests
-if !ENV['DOCKER_VERSION'] || ENV['DOCKER_VERSION'] =~ /^1\.\d\d/
-  SingleCov.setup :rspec
-end
+SingleCov.setup :rspec
 
 require 'docker'
 
@@ -37,96 +35,4 @@ RSpec.configure do |config|
   config.formatter = :documentation
   config.tty = true
   config.include SpecHelpers
-
-  # true -> exclude tests that require this version
-  # false -> exclude tests that stop working on and past this version
-  case ENV['DOCKER_VERSION']
-  when /^1\.6/
-    config.filter_run_excluding :docker_1_7 => true
-    config.filter_run_excluding :docker_1_8 => true
-    config.filter_run_excluding :docker_1_9 => true
-    config.filter_run_excluding :docker_1_10 => true
-    config.filter_run_excluding :docker_1_11 => true
-    config.filter_run_excluding :docker_1_12 => true
-    config.filter_run_excluding :docker_1_13 => true
-    config.filter_run_excluding :docker_17_03 => true
-    config.filter_run_excluding :docker_17_06 => true
-    config.filter_run_excluding :docker_17_09 => true
-  when /^1\.7/
-    config.filter_run_excluding :docker_1_8 => true
-    config.filter_run_excluding :docker_1_9 => true
-    config.filter_run_excluding :docker_1_10 => true
-    config.filter_run_excluding :docker_1_11 => true
-    config.filter_run_excluding :docker_1_12 => true
-    config.filter_run_excluding :docker_1_13 => true
-    config.filter_run_excluding :docker_17_03 => true
-    config.filter_run_excluding :docker_17_06 => true
-    config.filter_run_excluding :docker_17_09 => true
-  when /^1\.8/
-    config.filter_run_excluding :docker_1_9 => true
-    config.filter_run_excluding :docker_1_10 => true
-    config.filter_run_excluding :docker_1_11 => true
-    config.filter_run_excluding :docker_1_12 => true
-    config.filter_run_excluding :docker_1_13 => true
-    config.filter_run_excluding :docker_17_03 => true
-    config.filter_run_excluding :docker_17_06 => true
-    config.filter_run_excluding :docker_17_09 => true
-  when /^1\.9/
-    config.filter_run_excluding :docker_1_10 => true
-    config.filter_run_excluding :docker_1_11 => true
-    config.filter_run_excluding :docker_1_12 => true
-    config.filter_run_excluding :docker_1_13 => true
-    config.filter_run_excluding :docker_17_03 => true
-    config.filter_run_excluding :docker_17_06 => true
-    config.filter_run_excluding :docker_17_09 => true
-  when /^1\.10/
-    config.filter_run_excluding :docker_1_11 => true
-    config.filter_run_excluding :docker_1_12 => true
-    config.filter_run_excluding :docker_1_13 => true
-    config.filter_run_excluding :docker_17_03 => true
-    config.filter_run_excluding :docker_17_06 => true
-    config.filter_run_excluding :docker_17_09 => true
-  when /^1\.11/
-    config.filter_run_excluding :docker_1_12 => true
-    config.filter_run_excluding :docker_1_13 => true
-    config.filter_run_excluding :docker_17_03 => true
-    config.filter_run_excluding :docker_17_06 => true
-    config.filter_run_excluding :docker_17_09 => true
-  when /^1\.12/
-    config.filter_run_excluding :docker_1_12 => false
-    config.filter_run_excluding :docker_1_13 => true
-    config.filter_run_excluding :docker_17_03 => true
-    config.filter_run_excluding :docker_17_06 => true
-    config.filter_run_excluding :docker_17_09 => true
-  when /^1\.13/
-    config.filter_run_excluding :docker_1_12 => false
-    config.filter_run_excluding :docker_1_13 => false
-    config.filter_run_excluding :docker_17_03 => true
-    config.filter_run_excluding :docker_17_06 => true
-    config.filter_run_excluding :docker_17_09 => true
-  when /^17\.03/
-    config.filter_run_excluding :docker_1_12 => false
-    config.filter_run_excluding :docker_1_13 => false
-    config.filter_run_excluding :docker_17_06 => true
-    config.filter_run_excluding :docker_17_09 => true
-    config.filter_run_excluding :docker_old => true
-  when /^17\.06/
-    config.filter_run_excluding :docker_1_12 => false
-    config.filter_run_excluding :docker_1_13 => false
-    config.filter_run_excluding :docker_17_06 => false
-    config.filter_run_excluding :docker_17_09 => true
-    config.filter_run_excluding :docker_old => true
-  when /^17\.09/
-    config.filter_run_excluding :docker_1_12 => false
-    config.filter_run_excluding :docker_1_13 => false
-    config.filter_run_excluding :docker_17_06 => false
-    config.filter_run_excluding :docker_17_09 => false
-    config.filter_run_excluding :docker_old => true
-  when /^17\.12/
-    config.filter_run_excluding :docker_1_12 => false
-    config.filter_run_excluding :docker_1_13 => false
-    config.filter_run_excluding :docker_17_06 => false
-    config.filter_run_excluding :docker_17_09 => false
-    config.filter_run_excluding :docker_old => true
-  end
 end


### PR DESCRIPTION
* Updates Travis CI config to test modern docker engines and ruby versions
  * Also fixes broken testing configuration
* Removes version from path (fixes some broken API behavior)
* Fixes deprecation warnings from `URI.encode`
* Remove very legacy `Container#copy` (replaced by `Container#archive_out` in Docker v1.12)