### PR TITLE
Remove reference to `.validate_version!` from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@ irb(main):004:0> Docker.options
 => {}
 ```
 
-Before doing anything else, ensure you have the correct version of the Docker API. To do this, run `Docker.validate_version!`. If your installed version is not supported, a `Docker::Error::VersionError` is raised.
-
 ### SSL
 
 When running docker using SSL, setting the DOCKER_CERT_PATH will configure docker-api to use SSL.


### PR DESCRIPTION
In the version 2 upgrade, we removed the method in https://github.com/swipely/docker-api/pull/558/commits/f977568213354b4e8c347eeede1346d53aeec723 and its only usage in https://github.com/swipely/docker-api/commit/267f87f1970726513aa237204ce87fe10358dcbf. Cleaning up the reference in README so we can close https://github.com/swipely/docker-api/issues/561 too.