### PR TITLE
Set the content type header on build

### DIFF
--- a/lib/docker/image.rb
+++ b/lib/docker/image.rb
@@ -252,6 +252,7 @@ class Docker::Image
       body = ""
       connection.post(
         '/build', opts,
+        :headers => { 'Content-Type' => 'application/tar' },
         :body => Docker::Util.create_tar('Dockerfile' => commands),
         :response_block => response_block(body, &block)
       )


### PR DESCRIPTION
Prior to this patch, the application/json Content-Type header was set but he body is a tar file as returned by Docker::Util.create_tar. That this code was there for a long time suggests Docker doesn't check the content type. However, podman's REST API does check the header and rejects the request. After this patch, it is accepted.