### PR TITLE
Automatically retry with correct content-type

### DIFF
--- a/.cane
+++ b/.cane
@@ -1,2 +1,2 @@
---abc-max 19
---style-measure 100
+--abc-max 30
+--style-measure 120

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -1,0 +1,66 @@
+name: Unit Tests
+on:
+  push:
+    branches:
+      # A test branch for seeing if your tests will pass in your personal fork
+      - test_me_github
+  pull_request:
+    branches:
+      - main
+      - master
+jobs:
+  docker-rspec:
+    runs-on:
+      - ubuntu-latest
+    strategy:
+      matrix:
+        ruby:
+          - 2.7
+          - 2.6
+          - 2.5
+          - 2.4
+        docker_version:
+          - 5:19.03.8~3-0~ubuntu-bionic
+          - 5:18.09.9~3-0~ubuntu-bionic
+          - 18.06.3~ce~3-0~ubuntu
+      fail-fast: true
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: install bundler
+        run: |
+          gem install bundler -v '~> 1.17.3'
+          bundle update
+      - name: install docker
+        env:
+          DOCKER_VERSION: ${{ matrix.docker_version }}
+        run: sudo ./script/install_docker.sh ${DOCKER_VERSION} ${DOCKER_CE}
+      - name: spec tests
+        run: bundle exec rake
+
+  podman-rspec:
+    runs-on:
+      - ubuntu-latest
+    strategy:
+      matrix:
+        ruby:
+          - 2.7
+          - 2.6
+          - 2.5
+          - 2.4
+      fail-fast: true
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: install bundler
+        run: |
+          gem install bundler -v '~> 1.17.3'
+          bundle update
+      - name: install podman
+        run: sudo ./script/install_podman.sh
+      - name: spec tests
+        run: bundle exec rake

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   docker-rspec:
     runs-on:
-      - ubuntu-latest
+      - ubuntu-18.04
     strategy:
       matrix:
         ruby:
@@ -20,8 +20,9 @@ jobs:
           - 2.5
           - 2.4
         docker_version:
-          - 5:20.10.4~3-0~ubuntu-focal
-          - 5:19.03.9~3-0~ubuntu-focal
+          - ':20.'
+          - ':19.'
+          - ':18.'
       fail-fast: true
     steps:
       - uses: actions/checkout@v2
@@ -35,7 +36,23 @@ jobs:
       - name: install docker
         env:
           DOCKER_VERSION: ${{ matrix.docker_version }}
-        run: sudo ./script/install_docker.sh ${DOCKER_VERSION} ${DOCKER_CE}
+        run: |
+          set -x
+          sudo apt-get remove -y docker docker-engine docker.io containerd runc ||:
+          sudo apt-get update -y
+          sudo apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+          sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+          sudo apt-get update -y
+          sudo apt-cache gencaches
+          sudo apt-get install -y docker-ce=$( apt-cache madison docker-ce | grep -e $DOCKER_VERSION | cut -f 2 -d '|' | head -1 | sed 's/\s//g' )
+          if [ $? -ne 0 ]; then
+            echo "Error: Could not install ${DOCKER_VERSION}"
+            echo "Available docker versions:"
+            apt-cache madison docker-ce
+            exit 1
+          fi
+          sudo systemctl start docker
       - name: spec tests
         run: bundle exec rake
 

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -20,13 +20,12 @@ jobs:
           - 2.5
           - 2.4
         docker_version:
-          - 5:19.03.8~3-0~ubuntu-bionic
-          - 5:18.09.9~3-0~ubuntu-bionic
-          - 18.06.3~ce~3-0~ubuntu
+          - 5:20.10.4~3-0~ubuntu-focal
+          - 5:19.03.9~3-0~ubuntu-focal
       fail-fast: true
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: install bundler
@@ -53,7 +52,7 @@ jobs:
       fail-fast: true
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: install bundler

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Usage
 
 docker-api is designed to be very lightweight. Almost no state is cached (aside from id's which are immutable) to ensure that each method call's information is up to date. As such, just about every external method represents an API call.
 
+At this time, basic `podman` support has been added via the podman docker-compatible API socket.
+
 ## Starting up
 
 Follow the [installation instructions](https://docs.docker.com/install/), and then run:

--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ end
 
 desc 'Download the necessary base images'
 task :unpack do
-  %w( swipely/base registry busybox tianon/true debian:wheezy ).each do |image|
+  %w( swipely/base registry busybox tianon/true debian:stable ).each do |image|
     system "docker pull #{image}"
   end
 end

--- a/lib/docker.rb
+++ b/lib/docker.rb
@@ -121,16 +121,25 @@ module Docker
 
   # Determine if the server is podman or docker.
   def podman?(connection = self.connection)
-    not (
+    @attrs ||= {}
+    return @attrs[:podman] if @attrs[:podman]
+
+    @attrs[:podman] = !(
       Array(version(connection)['Components']).find do |component|
         component['Name'] && component['Name'].include?('Podman')
       end
     ).nil?
+
+    @attrs[:podman]
   end
 
   # Determine if the session is rootless.
   def rootless?(connection = self.connection)
-    info(connection)['Rootless'] == true
+    @attrs ||= {}
+    return @attrs[:rootless] if @attrs[:rootless]
+
+    @attrs[:rootless] = (info(connection)['Rootless'] == true)
+    @attrs[:rootless]
   end
 
   # Login to the Docker registry.

--- a/lib/docker.rb
+++ b/lib/docker.rb
@@ -106,40 +106,27 @@ module Docker
 
   # Get the version of Go, Docker, and optionally the Git commit.
   def version(connection = self.connection)
-    Util.parse_json(connection.get('/version'))
+    connection.version
   end
 
   # Get more information about the Docker server.
   def info(connection = self.connection)
-    Util.parse_json(connection.get('/info'))
+    connection.info
   end
 
   # Ping the Docker server.
   def ping(connection = self.connection)
-    connection.get('/_ping')
+    connection.ping
   end
 
   # Determine if the server is podman or docker.
   def podman?(connection = self.connection)
-    @attrs ||= {}
-    return @attrs[:podman] if @attrs[:podman]
-
-    @attrs[:podman] = !(
-      Array(version(connection)['Components']).find do |component|
-        component['Name'] && component['Name'].include?('Podman')
-      end
-    ).nil?
-
-    @attrs[:podman]
+    connection.podman?
   end
 
   # Determine if the session is rootless.
   def rootless?(connection = self.connection)
-    @attrs ||= {}
-    return @attrs[:rootless] if @attrs[:rootless]
-
-    @attrs[:rootless] = (info(connection)['Rootless'] == true)
-    @attrs[:rootless]
+    connection.rootless?
   end
 
   # Login to the Docker registry.

--- a/lib/docker.rb
+++ b/lib/docker.rb
@@ -119,6 +119,20 @@ module Docker
     connection.get('/_ping')
   end
 
+  # Determine if the server is podman or docker.
+  def podman?(connection = self.connection)
+    not (
+      Array(version(connection)['Components']).find do |component|
+        component['Name'] && component['Name'].include?('Podman')
+      end
+    ).nil?
+  end
+
+  # Determine if the session is rootless.
+  def rootless?(connection = self.connection)
+    info(connection)['Rootless'] == true
+  end
+
   # Login to the Docker registry.
   def authenticate!(options = {}, connection = self.connection)
     creds = MultiJson.dump(options)
@@ -132,5 +146,5 @@ module Docker
   module_function :default_socket_url, :env_url, :url, :url=, :env_options,
                   :options, :options=, :creds, :creds=, :logger, :logger=,
                   :connection, :reset!, :reset_connection!, :version, :info,
-                  :ping, :authenticate!, :ssl_options
+                  :ping, :podman?, :rootless?, :authenticate!, :ssl_options
 end

--- a/lib/docker/exec.rb
+++ b/lib/docker/exec.rb
@@ -19,6 +19,13 @@ class Docker::Exec
   # @return [Docker::Exec] self
   def self.create(options = {}, conn = Docker.connection)
     container = options.delete('Container')
+
+    # Podman does not attach these by default but does require them to be attached
+    if ::Docker.podman?
+      options['AttachStderr'] = true if options['AttachStderr'].nil?
+      options['AttachStdout'] = true if options['AttachStdout'].nil?
+    end
+
     resp = conn.post("/containers/#{container}/exec", {},
       body: MultiJson.dump(options))
     hash = Docker::Util.parse_json(resp) || {}

--- a/script/install_docker.sh
+++ b/script/install_docker.sh
@@ -10,7 +10,7 @@ DOCKER_CE=$2
 
 # disable travis default installation
 systemctl stop docker.service
-apt-get -y --purge remove docker docker-engine docker-ce
+apt-get -y --purge remove docker docker-engine docker.io containerd runc
 
 # install gpg key for docker rpo
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
@@ -24,8 +24,18 @@ add-apt-repository \
 apt-get update
 apt-cache gencaches
 
+set +e
 # install package
 apt-get install docker-ce=${DOCKER_VERSION}
+
+if [ $? -ne 0 ]; then
+  echo "Error: Could not install ${DOCKER_VERSION}"
+  echo "Available docker versions:"
+  apt-cache madison docker-ce
+  exit 1
+fi
+set -e
+
 systemctl stop docker.service
 
 echo 'DOCKER_OPTS="-H unix:///var/run/docker.sock --pidfile=/var/run/docker.pid"' > /etc/default/docker

--- a/script/install_podman.sh
+++ b/script/install_podman.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -ex
+
+. /etc/os-release
+
+curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
+
+echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_18.04/ /" > /etc/apt/sources.list.d/podman.list
+
+apt-get update
+
+apt-get install -y podman

--- a/spec/docker/connection_spec.rb
+++ b/spec/docker/connection_spec.rb
@@ -20,11 +20,11 @@ describe Docker::Connection do
 
     context 'when the first argument is a String' do
       context 'and the url is a unix socket' do
-        let(:url) { 'unix:///var/run/docker.sock' }
+        let(:url) { ::Docker.env_url || ::Docker.default_socket_url }
 
         it 'sets the socket path in the options' do
           expect(subject.url).to eq('unix:///')
-          expect(subject.options).to include(:socket => '/var/run/docker.sock')
+          expect(subject.options).to include(:socket => url.split('//').last)
         end
       end
 

--- a/spec/docker/connection_spec.rb
+++ b/spec/docker/connection_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-SingleCov.covered! uncovered: 11
+SingleCov.covered! uncovered: 12
 
 describe Docker::Connection do
   subject { described_class.new('http://localhost:4243', {}) }

--- a/spec/docker/connection_spec.rb
+++ b/spec/docker/connection_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-SingleCov.covered! uncovered: 7
+SingleCov.covered! uncovered: 11
 
 describe Docker::Connection do
   subject { described_class.new('http://localhost:4243', {}) }

--- a/spec/docker/event_spec.rb
+++ b/spec/docker/event_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-SingleCov.covered! uncovered: 4
+SingleCov.covered! uncovered: 5
 
 describe Docker::Event do
   let(:api_response) do
@@ -35,7 +35,7 @@ describe Docker::Event do
 
       let(:status) { "start" }
       let(:id) { "398c9f77b5d2" }
-      let(:from) { "debian:wheezy" }
+      let(:from) { "debian:stable" }
       let(:time) { 1381956164 }
 
       let(:expected_string) {
@@ -75,7 +75,7 @@ describe Docker::Event do
         end
       end
 
-      container = Docker::Image.create('fromImage' => 'debian:wheezy')
+      container = Docker::Image.create('fromImage' => 'debian:stable')
         .run('bash')
         .tap(&:wait)
 
@@ -91,6 +91,7 @@ describe Docker::Event do
     let(:time) { Time.now.to_i + 1 }
 
     it 'receives at least 4 events' do
+      skip('Not supported on podman') if ::Docker.podman?
       events = 0
 
       stream_thread = Thread.new do
@@ -102,7 +103,7 @@ describe Docker::Event do
         end
       end
 
-      container = Docker::Image.create('fromImage' => 'debian:wheezy')
+      container = Docker::Image.create('fromImage' => 'debian:stable')
         .run('bash')
         .tap(&:wait)
 
@@ -119,7 +120,7 @@ describe Docker::Event do
       let(:event) { Docker::Event.new_event(response_body, nil, nil) }
       let(:status) { "start" }
       let(:id) { "398c9f77b5d2" }
-      let(:from) { "debian:wheezy" }
+      let(:from) { "debian:stable" }
       let(:time) { 1381956164 }
       let(:response_body) {
         "{\"status\":\"#{status}\",\"id\":\"#{id}\""\

--- a/spec/docker/exec_spec.rb
+++ b/spec/docker/exec_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
-SingleCov.covered! uncovered: 4
+SingleCov.covered! uncovered: 5
 
 describe Docker::Exec do
   let(:container) {
     Docker::Container.create(
       'Cmd' => %w(sleep 300),
-      'Image' => 'debian:wheezy'
+      'Image' => 'debian:stable'
     ).start!
   }
 
@@ -59,7 +59,8 @@ describe Docker::Exec do
     context 'when the parent container does not exist' do
       before do
         Docker.options = { :mock => true }
-        Excon.stub({ :method => :post }, { :status => 404 })
+        Excon.stub({ :method => :get}, { :status => 404 }) # For Podman
+        Excon.stub({ :method => :post}, { :status => 404 })
       end
       after do
         Excon.stubs.shift

--- a/spec/docker/network_spec.rb
+++ b/spec/docker/network_spec.rb
@@ -1,158 +1,160 @@
 require 'spec_helper'
 
-SingleCov.covered! uncovered: 2
+unless ::Docker.podman?
+  SingleCov.covered! uncovered: 2
 
-describe Docker::Network, docker_1_9: true do
-  let(:name) do |example|
-    example.description.downcase.gsub(/\s/, '-')
-  end
-
-  describe '#to_s' do
-    subject { described_class.new(Docker.connection, info) }
-    let(:connection) { Docker.connection }
-
-    let(:id) do
-      'a6c5ffd25e07a6c906accf804174b5eb6a9d2f9e07bccb8f5aa4f4de5be6d01d'
+  describe Docker::Network, docker_1_9: true do
+    let(:name) do |example|
+      example.description.downcase.gsub(/\s/, '-')
     end
 
-    let(:info) do
-      {
-        'Name' => 'bridge',
-        'Scope' => 'local',
-        'Driver' => 'bridge',
-        'IPAM' => {
-          'Driver' => 'default',
-          'Config' => [{ 'Subnet' => '172.17.0.0/16' }]
-        },
-        'Containers' => {},
-        'Options' => {
-          'com.docker.network.bridge.default_bridge' => 'true',
-          'com.docker.network.bridge.enable_icc' => 'true',
-          'com.docker.network.bridge.enable_ip_masquerade' => 'true',
-          'com.docker.network.bridge.host_binding_ipv4' => '0.0.0.0',
-          'com.docker.network.bridge.name' => 'docker0',
-          'com.docker.network.driver.mtu' => '1500'
-        },
-        'id' => id
-      }
+    describe '#to_s' do
+      subject { described_class.new(Docker.connection, info) }
+      let(:connection) { Docker.connection }
+
+      let(:id) do
+        'a6c5ffd25e07a6c906accf804174b5eb6a9d2f9e07bccb8f5aa4f4de5be6d01d'
+      end
+
+      let(:info) do
+        {
+          'Name' => 'bridge',
+          'Scope' => 'local',
+          'Driver' => 'bridge',
+          'IPAM' => {
+            'Driver' => 'default',
+            'Config' => [{ 'Subnet' => '172.17.0.0/16' }]
+          },
+          'Containers' => {},
+          'Options' => {
+            'com.docker.network.bridge.default_bridge' => 'true',
+            'com.docker.network.bridge.enable_icc' => 'true',
+            'com.docker.network.bridge.enable_ip_masquerade' => 'true',
+            'com.docker.network.bridge.host_binding_ipv4' => '0.0.0.0',
+            'com.docker.network.bridge.name' => 'docker0',
+            'com.docker.network.driver.mtu' => '1500'
+          },
+          'id' => id
+        }
+      end
+
+      let(:expected_string) do
+        "Docker::Network { :id => #{id}, :info => #{info.inspect}, "\
+          ":connection => #{connection} }"
+      end
+
+      its(:to_s) { should == expected_string }
     end
 
-    let(:expected_string) do
-      "Docker::Network { :id => #{id}, :info => #{info.inspect}, "\
-        ":connection => #{connection} }"
+    describe '.create' do
+      let!(:id) { subject.id }
+      subject { described_class.create(name) }
+      after { described_class.remove(id) }
+
+      it 'creates a Network' do
+        expect(Docker::Network.all.map(&:id)).to include(id)
+      end
     end
 
-    its(:to_s) { should == expected_string }
-  end
+    describe '.remove' do
+      let(:id) { subject.id }
+      subject { described_class.create(name) }
 
-  describe '.create' do
-    let!(:id) { subject.id }
-    subject { described_class.create(name) }
-    after { described_class.remove(id) }
-
-    it 'creates a Network' do
-      expect(Docker::Network.all.map(&:id)).to include(id)
-    end
-  end
-
-  describe '.remove' do
-    let(:id) { subject.id }
-    subject { described_class.create(name) }
-
-    it 'removes the Network' do
-      described_class.remove(id)
-      expect(Docker::Network.all.map(&:id)).to_not include(id)
-    end
-  end
-
-  describe '.get' do
-    after do
-      described_class.remove(name)
+      it 'removes the Network' do
+        described_class.remove(id)
+        expect(Docker::Network.all.map(&:id)).to_not include(id)
+      end
     end
 
-    let!(:network) { described_class.create(name) }
+    describe '.get' do
+      after do
+        described_class.remove(name)
+      end
 
-    it 'returns a network' do
-      expect(Docker::Network.get(name).id).to eq(network.id)
-    end
-  end
+      let!(:network) { described_class.create(name) }
 
-  describe '.all' do
-    let!(:networks) do
-      5.times.map { |i| described_class.create("#{name}-#{i}") }
-    end
-
-    after do
-      networks.each(&:remove)
+      it 'returns a network' do
+        expect(Docker::Network.get(name).id).to eq(network.id)
+      end
     end
 
-    it 'should return all networks' do
-      expect(Docker::Network.all.map(&:id)).to include(*networks.map(&:id))
-    end
-  end
+    describe '.all' do
+      let!(:networks) do
+        5.times.map { |i| described_class.create("#{name}-#{i}") }
+      end
 
-  describe '.prune', :docker_17_03 => true do
-    it 'prune networks' do
-      expect { Docker::Network.prune }.not_to raise_error
-    end
-  end
+      after do
+        networks.each(&:remove)
+      end
 
-  describe '#connect' do
-    let!(:container) do
-      Docker::Container.create(
-        'Cmd' => %w(sleep 10),
-        'Image' => 'debian:wheezy'
-      )
-    end
-    subject { described_class.create(name) }
-
-    before(:each) { container.start }
-    after(:each) do
-      container.kill!.remove
-      subject.remove
+      it 'should return all networks' do
+        expect(Docker::Network.all.map(&:id)).to include(*networks.map(&:id))
+      end
     end
 
-    it 'connects a container to a network' do
-      subject.connect(container.id)
-      expect(subject.info['Containers']).to include(container.id)
-    end
-  end
-
-  describe '#disconnect' do
-    let!(:container) do
-      Docker::Container.create(
-        'Cmd' => %w(sleep 10),
-        'Image' => 'debian:wheezy'
-      )
+    describe '.prune', :docker_17_03 => true do
+      it 'prune networks' do
+        expect { Docker::Network.prune }.not_to raise_error
+      end
     end
 
-    subject { described_class.create(name) }
+    describe '#connect' do
+      let!(:container) do
+        Docker::Container.create(
+          'Cmd' => %w(sleep 10),
+          'Image' => 'debian:stable'
+        )
+      end
+      subject { described_class.create(name) }
 
-    before(:each) do
-      container.start
-      sleep 1
-      subject.connect(container.id)
+      before(:each) { container.start }
+      after(:each) do
+        container.kill!.remove
+        subject.remove
+      end
+
+      it 'connects a container to a network' do
+        subject.connect(container.id)
+        expect(subject.info['Containers']).to include(container.id)
+      end
     end
 
-    after(:each) do
-      container.kill!.remove
-      subject.remove
+    describe '#disconnect' do
+      let!(:container) do
+        Docker::Container.create(
+          'Cmd' => %w(sleep 10),
+          'Image' => 'debian:stable'
+        )
+      end
+
+      subject { described_class.create(name) }
+
+      before(:each) do
+        container.start
+        sleep 1
+        subject.connect(container.id)
+      end
+
+      after(:each) do
+        container.kill!.remove
+        subject.remove
+      end
+
+      it 'connects a container to a network' do
+        subject.disconnect(container.id)
+        expect(subject.info['Containers']).not_to include(container.id)
+      end
     end
 
-    it 'connects a container to a network' do
-      subject.disconnect(container.id)
-      expect(subject.info['Containers']).not_to include(container.id)
-    end
-  end
+    describe '#remove' do
+      let(:id) { subject.id }
+      let(:name) { 'test-network-remove' }
+      subject { described_class.create(name) }
 
-  describe '#remove' do
-    let(:id) { subject.id }
-    let(:name) { 'test-network-remove' }
-    subject { described_class.create(name) }
-
-    it 'removes the Network' do
-      subject.remove
-      expect(Docker::Network.all.map(&:id)).to_not include(id)
+      it 'removes the Network' do
+        subject.remove
+        expect(Docker::Network.all.map(&:id)).to_not include(id)
+      end
     end
   end
 end

--- a/spec/docker_spec.rb
+++ b/spec/docker_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-SingleCov.covered! uncovered: 2
+SingleCov.covered! uncovered: 7
 
 describe Docker do
   subject { Docker }
@@ -231,6 +231,7 @@ describe Docker do
       }
 
       it "raises an error and doesn't set the creds" do
+        skip('Not supported on podman') if ::Docker.podman?
         expect {
           authentication
         }.to raise_error(Docker::Error::AuthenticationError)

--- a/spec/docker_spec.rb
+++ b/spec/docker_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-SingleCov.covered! uncovered: 7
+SingleCov.covered! uncovered: 8
 
 describe Docker do
   subject { Docker }

--- a/spec/fixtures/build_from_dir/Dockerfile
+++ b/spec/fixtures/build_from_dir/Dockerfile
@@ -1,2 +1,2 @@
-FROM debian:wheezy
+FROM debian:stable
 ADD . /

--- a/spec/fixtures/top/Dockerfile
+++ b/spec/fixtures/top/Dockerfile
@@ -1,2 +1,4 @@
-FROM debian:wheezy
+FROM debian:stable
+RUN apt-get update
+RUN apt-get install -y procps
 RUN printf '#! /bin/sh\nwhile true\ndo\ntrue\ndone\n' > /while && chmod +x /while


### PR DESCRIPTION
The podman socket will return a note about the correct content-type that
should be used for a given type of message if it is incorrect.

This is a workaround to automatically correct the content-type and
resubmit the call.

A full correction would be to update all of the different connection
entries but this appears to work correctly in the short term.

Fixes #568