### PR TITLE
Add Container#resize support

### DIFF
--- a/lib/docker/container.rb
+++ b/lib/docker/container.rb
@@ -322,6 +322,18 @@ class Docker::Container
     archive_in_stream("/", overwrite: true) { output_io.read }
   end
 
+  # Resize the TTY associated with the Container instance
+  #
+  # @param query [Hash] API query parameters
+  # @option query [Fixnum] h Height of the TTY
+  # @option query [Fixnum] w Width of the TTY
+  #
+  # @return [Docker::Container] self
+  def resize(query = {})
+    connection.post(path_for(:resize), query)
+    self
+  end
+
   # Create a new Container.
   def self.create(opts = {}, conn = Docker.connection)
     query = opts.select {|key| ['name', :name].include?(key) }


### PR DESCRIPTION
This PR adds `#resize` to Container instances. It is the same code as the one from `Exec#resize` with slight changes to the documentation.

There seems to be no tests for `Exec#resize`, so I decided on checking here for ideas prior to writing anything. One suggestion would be to create a container, resize it, run `tput lines` (and `tput cols`) and verify that the output is as expected, but I'm not entirely sure on the best way to go about it.

