### PR TITLE
Add "scope" support to Docker::Event (#593)

### DIFF
--- a/docker-api.gemspec
+++ b/docker-api.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'multi_json'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec', '~> 3.0'
-  gem.add_development_dependency 'rspec-its'
+  gem.add_development_dependency 'rspec-its', '~> 1'
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'single_cov'
   gem.add_development_dependency 'webmock'

--- a/lib/docker/connection.rb
+++ b/lib/docker/connection.rb
@@ -137,24 +137,24 @@ class Docker::Connection
   end
 
 private
-  # Given an HTTP method, path, optional query, extra options, and block,
-  # compiles a request.
+
   def compile_request_params(http_method, path, query = nil, opts = nil, &block)
-    query ||= {}
     opts ||= {}
-    headers = opts.delete(:headers) || {}
-    content_type = opts[:body].nil? ?  'text/plain' : 'application/json'
-    user_agent = "Swipely/Docker-API #{Docker::VERSION}"
+    query ||= opts.delete(:query) || {}
+
+    default_headers = {
+      'Content-Type' => opts[:body].nil? ? 'text/plain' : 'application/json',
+      'User-Agent' => "Swipely/Docker-API #{Docker::VERSION}",
+    }
+    headers = default_headers.merge(opts.delete(:headers) || {})
+
     {
-      :method        => http_method,
-      :path          => path,
-      :query         => query,
-      :headers       => { 'Content-Type' => content_type,
-                          'User-Agent'   => user_agent,
-                        }.merge(headers),
-      :expects       => (200..204).to_a << 301 << 304,
-      :idempotent    => http_method == :get,
-      :request_block => block,
-    }.merge(opts).reject { |_, v| v.nil? }
+      method: http_method,
+      path: path,
+      headers:,
+      query:,
+      expects: (200..204).to_a << 301 << 304,
+      idempotent: http_method == :get,
+    }.merge(opts).tap { |params| params[:request_block] = block if block }
   end
 end

--- a/lib/docker/connection.rb
+++ b/lib/docker/connection.rb
@@ -151,8 +151,8 @@ private
     {
       method: http_method,
       path: path,
-      headers:,
-      query:,
+      headers: headers,
+      query: query,
       expects: (200..204).to_a << 301 << 304,
       idempotent: http_method == :get,
     }.merge(opts).tap { |params| params[:request_block] = block if block }

--- a/script/install_podman.sh
+++ b/script/install_podman.sh
@@ -1,12 +1,5 @@
 #!/bin/sh
 set -ex
 
-. /etc/os-release
-
-curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
-
-echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" > /etc/apt/sources.list.d/podman.list
-
 apt-get update
-
 apt-get install -y podman

--- a/spec/docker/event_spec.rb
+++ b/spec/docker/event_spec.rb
@@ -19,6 +19,7 @@ describe Docker::Event do
       'Type' => 'container',
       'from' => 'tianon/true',
       'id' => 'bb2c783a32330b726f18d1eb44d80c899ef45771b4f939326e0fefcfc7e05db8',
+      'scope' => 'local',
       'status' => 'start',
       'time' => 1461083270,
       'timeNano' => 1461083270652069004
@@ -193,6 +194,7 @@ describe Docker::Event do
           event.actor.id
         ).to eq('bb2c783a32330b726f18d1eb44d80c899ef45771b4f939326e0fefcfc7e05db8')
         expect(event.actor.attributes).to eq('image' => 'tianon/true', 'name' => 'true-dat')
+        expect(event.scope).to eq('local')
         expect(event.time).to eq 1461083270
         expect(event.time_nano).to eq 1461083270652069004
       end

--- a/spec/docker/event_spec.rb
+++ b/spec/docker/event_spec.rb
@@ -117,7 +117,7 @@ describe Docker::Event do
           # Filter to avoid unexpected Docker events interfering with timeout behavior
           query: { filters: { container: [SecureRandom.uuid] }.to_json },
           # Use [] to differentiate between explicit nil and not providing an arg (falling back to the default)
-          read_timeout:,
+          read_timeout: read_timeout,
         }.reject { |_, v| v.empty? rescue false }
 
         Docker::Event.stream(opts) do |event|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,10 @@ RSpec.shared_context "local paths" do
 end
 
 module SpecHelpers
+  def skip_slow_test
+    skip "Disabled because ENV['RUN_SLOW_TESTS'] not set" unless ENV['RUN_SLOW_TESTS']
+  end
+
   def skip_without_auth
     skip "Disabled because of missing auth" if ENV['DOCKER_API_USER'] == 'debbie_docker'
   end


### PR DESCRIPTION
## Summary

Resolves #593 by:
- Refactoring Docker::Event to provide access to its source (JSON) data.
- Adding `scope` to the Docker::Event class.

## Discussion

The refactoring simplifies the Docker::Event interface and brings it closer to that of the other Docker:: classes. Users can access the normalized event data via `event.info` and `event.actor.info`. Since the Docker API uses a mix of camelCase and PascalCase strings as response keys, the `info` keys are normalized to downcased symbols and helper methods have been added.

For example:

```ruby
# Actor
event.actor # instance of Docker::Event::Actor
event.info[:actor]

# Action
event.action # string value
event.info[:action]

# timeNano
event.time_nano
event.timeNano # helper method named the same as the spec'd attribute
event.info[:timenano] # note downcasing but not snakecase conversion

# scope (added in this PR)
event.scope
event.info[:scope]
```

I would discourage users from using the alias methods (`event.Actor`, `event.Type`, etc.), but I kept them in for backwards-compatibility.

Since Docker Engine Events are read-only, I modified the Event class to remove mutability where it was possible (specifically, `event.actor=`).

Finally, as can be seen in the above example, I added the `scope` attribute along with a test.

## Check Failures

As of [run 14625174071](https://github.com/upserve/docker-api/actions/runs/14625174071), it looks like the pipeline itself is broken. The relevant event_spec tests pass, but all podman tests fail and some docker tests fail with an unrelated error ("private method `resource' called for an instance of Docker::Connection").