### PR TITLE
Run CI Against Podman

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -81,7 +81,22 @@ jobs:
           bundler-cache: true
       - name: Update gems
         run: bundle update
-      - name: install podman
-        run: sudo ./script/install_podman.sh
+      - name: Start rootless Podman API service
+        run: |
+          mkdir -p "${HOME}/var/run"
+          podman system service unix://${HOME}/var/run/podman.sock --time=0 &
+          echo $! > $HOME/podman_service.pid
+          # Wait until the socket is ready
+          for i in $(seq 1 20); do
+            if podman --url unix://${HOME}/var/run/podman.sock info >/dev/null 2>&1 ; then
+              echo "Podman socket ready"; break
+            fi
+            echo "Waiting for podman socket…"
+            sleep 1
+          done
+      - name: Point Docker-API at Podman
+        run: |
+          echo "DOCKER_HOST=unix://${HOME}/var/run/podman.sock" >> $GITHUB_ENV
+          echo "EXPECT_PODMAN=true" >> $GITHUB_ENV
       - name: spec tests
         run: bundle exec rake

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,17 @@ SingleCov.setup :rspec
 
 require 'docker'
 
+# Hard-fail the build if we said we expected Podman but did not get it
+if (ENV['EXPECT_PODMAN'] == 'true') && !Docker.podman?
+  warn <<~MSG
+    EXPECT_PODMAN=true was set, but Docker.podman? returned false.
+    Connected engine information:
+    #{Docker.version}
+    Make sure the Podman API socket is running and DOCKER_HOST points to it.
+  MSG
+  exit 1
+end
+
 ENV['DOCKER_API_USER']  ||= 'debbie_docker'
 ENV['DOCKER_API_PASS']  ||= '*************'
 ENV['DOCKER_API_EMAIL'] ||= 'debbie_docker@example.com'


### PR DESCRIPTION
The existing `podman-rspec` job in the `unit_test.yaml` workflow only _installed_ Podman, but never started the engine. As a result the tets still talked to the pre-installed Docker daemon on `/var/run/docker.sock`, since that's what it defaults to. `Docker.podman?` never returned `true` and we were silently re-running the test suite with Docker.

https://github.com/actions/runner-images/blob/27d8a9d9026ab6e207340dde6e14f4faf3864e29/images/ubuntu/scripts/build/install-docker.sh#L60-L61

You can see that in the `podman-rspec` test runs, there are no specs skipped due to `skip('Not supported on podman') if ::Docker.podman?`, meaning we're not using Podman.

### Proposed solution
#### 1. Start a real Podman API service  

`podman system service unix://…` is launched in the runner’s home directory and kept alive for the whole job.

#### 2. Point the test suite at that socket  
   
We export `DOCKER_HOST` so the gem connects to Podman, and set an `EXPECT_PODMAN` flag.

#### 3. Fail fast if mis-configured  
A guard in `spec_helper.rb` hard-exits when `EXPECT_PODMAN=true` but `Docker.podman?` is still `false`.

#### 4. Remove Podman installation (Maybe?)  

Podman is already pre-installed on GitHub Ubuntu runners so the custom install script is no longer called. But, perhaps it's better to keep it to ensure it's always available.

### Additional notes
* The new guard is a no-op in local development unless you explicitly set `EXPECT_PODMAN=true`.
* If the Podman socket fails to start or the environment is mis-wired, the build fails immediately with a clear error message.
* No additional packages or elevated privileges are required; the service runs rootless in the runner’s home directory.
* Docker workflow remains unchanged and continues to validate against multiple Docker Engine versions.